### PR TITLE
Add a ProjectileFlags system to PD targeting

### DIFF
--- a/Data/Scripts/CoreParts/Weapon75Part.cs
+++ b/Data/Scripts/CoreParts/Weapon75Part.cs
@@ -11,6 +11,8 @@ using static Scripts.Structure.WeaponDefinition.TargetingDef.CommunicationDef.Se
 using static Scripts.Structure.WeaponDefinition.HardPointDef.HardwareDef;
 using static Scripts.Structure.WeaponDefinition.HardPointDef.HardwareDef.HardwareType;
 using static Scripts.Structure.WeaponDefinition.HardPointDef.LoadingDef;
+using static Scripts.Structure.WeaponDefinition.HardPointDef.UiDef;
+using static Scripts.Structure.WeaponDefinition.ProjectileFlags;
 
 namespace Scripts {   
     partial class Parts {
@@ -45,15 +47,55 @@ namespace Scripts {
             Targeting = new TargetingDef
             {
                 Threats = new[] {
-                    Grids, // Types of threat to engage: Grids, Projectiles, Characters, Meteors, Neutrals, ScanRoid, ScanPlanet, ScanFriendlyCharacter, ScanFriendlyGrid, ScanEnemyCharacter, ScanEnemyGrid, ScanNeutralCharacter, ScanNeutralGrid, ScanUnOwnedGrid, ScanOwnersGrid
+                    Grids, Projectiles // Types of threat to engage: Grids, Projectiles, Characters, Meteors, Neutrals, ScanRoid, ScanPlanet, ScanFriendlyCharacter, ScanFriendlyGrid, ScanEnemyCharacter, ScanEnemyGrid, ScanNeutralCharacter, ScanNeutralGrid, ScanUnOwnedGrid, ScanOwnersGrid
                            // Grids are both LG and SG. Use Hardpoint.Other.ProhibitLGTargeting and Use Hardpoint.Other.ProhibitSGTargeting to further differentiate
                 },
+                // ProjectileThreats you to further specify what Projectiles to target if Projectiles is listed above.
+                // This allows you to fine tune what your PDC will fire at, be it Dumb only, Smart only, or more specifically Explosive Smart projectiles, or Smarts that IgnoreAntiSmarts
+                // This also comes with custom flags that are only set in ammo definitions
+                // This is NOT a priority system, items higher on the list are not prioritized whatosever!
+                // Note: this depreciates the IgnoreDumbProjectiles setting, if you want that back then put it in the array as seen at the bottom.
+                // Note: This operates on an OR system by default (RequireExactProjectileThreats = true changes this to an AND system), ie. if you list both IsDumb and IsSmart, then it will basically target any projectile.
+                // Note: Atleast one value is needed or this fails to compile.
+                ProjectileThreats = new[] {
+                    IsDumb, // - Automatically set if the projectile guidance is None
+                    IsSmart, // - Automatically set if the projectile guidance is Smart
+                    IsDrone, // - Automatically set if the projectile guidance is DroneAdvanced
+                    IsMine, // - Automatically set if the projectile is one of the Mine guidance types
+                    IsTravelTo, // - Automatically set if the projectile guidance is TravelTo
+
+                    NoEwar, // Set if Ewar.Enable = false
+                    EwarEffect, // Set if Ewar.Enable = true and Ewar.Mode = Effect
+                    EwarField, // Set if Ewar.Enable = true and Ewar.Mode = Field
+                    Ewar, // Equivalent to writing `EwarEffect, EwarField,`
+
+                    NonExplosive, // Set if ByBlockHit.Enable = false and EndOfLife.Enable = false
+                    BBHExplosive, // Set if ByBlockHit.Enable = true
+                    EOLExplosive, // Set if EndOfLife.Enable = true
+                    Explosive, // Equivalent to writing `BBHExplosive, EOLExplosive,`
+
+                    NoFragments, // Set if the ammo def does not have a fragment defined
+                    HasFragments, // Set if the ammo def has a fragment defined
+
+                    AffectedByAntiSmarts, // Set if IsSmart = true and Trajectory.Smarts.IgnoreAntiSmarts = true
+                    IgnoresAntiSmarts, //  Set if IsSmart = true and Trajectory.Smarts.IgnoreAntiSmarts = false
+
+                    // Custom flags are flags set manually in AmmoDef.ProjectileFlagsOverride, and can be used to further specify things
+                    // Ie. using Custom01 for cannons, Custom02 for railguns, Custom03 for rockets, etc.
+                    // These can be somewhat wonky between differing modpacks, so recommend for server admins only really
+                    Custom01, Custom02, //... Custom## ... Custom20
+                    //AllCustom, // can be used in place of writing all 20 custom flags if you want all of them set for some reason
+
+                    All, // Equivalent to writing out every flag on the list (and invalid bits)
+                    
+                    //IgnoreDumbProjectiles // Equivalent to the old IgnoreDumbProjectiles setting
+                },
+                RequireAllProjectileThreats = false, // If true, only engages projectiles that have atleast all flags specified above. If false, engages any projectile that has at least one of the specified flags.
                 SubSystems = new[] {
                     Thrust, Utility, Offense, Power, Production, Any, // Subsystem targeting priority: Offense, Utility, Power, Production, Thrust, Jumping, Steering, Any
                                                                       // Order matters! With the current setting weapons will target Thrust first, then Utility, then Offense, etc.
                 },
                 ClosestFirst = true, // Tries to pick closest targets first (blocks on grids, projectiles, etc...).
-                IgnoreDumbProjectiles = false, // Don't fire at non-smart projectiles.
                 LockedSmartOnly = false, // Only fire at smart projectiles that are locked on to parent grid.
                 MinimumDiameter = 0, // Minimum diameter of threat to engage.
                 MaximumDiameter = 0, // Maximum diameter of threat to engage; 0 = unlimited.
@@ -113,6 +155,76 @@ namespace Scripts {
                     DisableSupportingPD = false, // If true, the supporting point defense terminal option will be removed and this weapon will only target projectiles targeting the construct it's placed on
                     ProhibitShotDelay = false, // If true, removes shot delay options for players.  This may be desirable for weapons that use heat or bursts as a balance mechanic and deliberately do not offer the ROF slider.
                     ProhibitBurstCount = false, // If true, removes burst shot count options for players.
+                    UiFlagsToggle = new ProjectileFlagsToggleDef
+                    {
+                        // Enabling this allows users to toggle projectile flags listed here.
+                        // User flags will take priority if they are set here with the above list in Targeting serving as defaults.
+                        // Ie. If IsDumb is listed in Targeting and here the user can toggle it on and off, and will default on
+                        //     If IsDumb is NOT listed in Targeting and here the user can toggle it on and off, and will default off
+                        //     If IsDumb is listed in Targeting and NOT here then it will be forced on
+                        Enable = false,
+
+                        // ProjectileThreats you to further specify what Projectiles to target if Projectiles is listed above.
+                        // This allows you to fine tune what your PDC will fire at, be it Dumb only, Smart only, or more specifically Explosive Smart projectiles, or Smarts that IgnoreAntiSmarts
+                        // This also comes with custom flags that are only set in ammo definitions
+                        // This is NOT a priority system, items higher on the list are not prioritized whatosever!
+                        // Listed ones will default true regardless of what is listed above
+                        ProjectileThreatToggles = new[] {
+                            IsDumb, // - Automatically set if the projectile guidance is None
+                            IsSmart, // - Automatically set if the projectile guidance is Smart
+                            IsDrone, // - Automatically set if the projectile guidance is DroneAdvanced
+                            IsMine, // - Automatically set if the projectile is one of the Mine guidance types
+                            IsTravelTo, // - Automatically set if the projectile guidance is TravelTo
+
+                            //NoEwar, // Set if Ewar.Enable = false
+                            //EwarEffect, // Set if Ewar.Enable = true and Ewar.Mode = Effect
+                            //EwarField, // Set if Ewar.Enable = true and Ewar.Mode = Field
+                            //Ewar, // Equivalent to writing `EwarEffect, EwarField,`
+
+                            //NonExplosive, // Set if ByBlockHit.Enable = false and EndOfLife.Enable = false
+                            //BBHExplosive, // Set if ByBlockHit.Enable = true
+                            //EOLExplosive, // Set if EndOfLife.Enable = true
+                            //Explosive, // Equivalent to writing `BBHExplosive, EOLExplosive,`
+
+                            //NoFragments, // Set if the ammo def does not have a fragment defined
+                            //HasFragments, // Set if the ammo def has a fragment defined
+
+                            //AffectedByAntiSmarts, // Set if IsSmart = true and Trajectory.Smarts.IgnoreAntiSmarts = true
+                            //IgnoresAntiSmarts, //  Set if IsSmart = true and Trajectory.Smarts.IgnoreAntiSmarts = false
+
+                            // Custom flags are flags set manually in AmmoDef.ProjectileFlagsOverride, and can be used to further specify things
+                            // Ie. using Custom01 for cannons, Custom02 for railguns, Custom03 for rockets, etc.
+                            // Note that these flags on projectiles can change meaning from mod to mod! Recommended for server admins only, or if enough people decide what each flag is
+                            Custom01, Custom02, //... Custom## ... Custom20
+                            //AllCustom, // can be used in place of writing all 20 custom flags if you want all of them set for some reason
+
+                            //All, // Do not put here even if its technically a valid option, as it will set unused bits which WILL show up in the UI
+                        },
+                        RequireAllProjectileThreatsToggle = false, // Allow the user to toggle RequireAllProjectileThreats, and will default off regardless of what is listed above if true
+
+                        // Custom display names for the Custom01-Custom20 flags in the UI. Note that these flags on projectiles can change meaning from mod to mod!
+                        Custom01DisplayName = "",
+                        Custom02DisplayName = "",
+                        Custom03DisplayName = "",
+                        Custom04DisplayName = "",
+                        Custom05DisplayName = "",
+                        Custom06DisplayName = "",
+                        Custom07DisplayName = "",
+                        Custom08DisplayName = "",
+                        Custom09DisplayName = "",
+                        Custom10DisplayName = "",
+                        Custom11DisplayName = "",
+                        Custom12DisplayName = "",
+                        Custom13DisplayName = "",
+                        Custom14DisplayName = "",
+                        Custom15DisplayName = "",
+                        Custom16DisplayName = "",
+                        Custom17DisplayName = "",
+                        Custom18DisplayName = "",
+                        Custom19DisplayName = "",
+                        Custom20DisplayName = "",
+
+                    }
                 },
                 Ai = new AiDef
                 {

--- a/Data/Scripts/CoreParts/Weapon75ammo.cs
+++ b/Data/Scripts/CoreParts/Weapon75ammo.cs
@@ -34,6 +34,7 @@ using static Scripts.Structure.WeaponDefinition.AmmoDef.GraphicDef.LineDef.Trace
 using static Scripts.Structure.WeaponDefinition.AmmoDef.GraphicDef.LineDef.Texture;
 using static Scripts.Structure.WeaponDefinition.AmmoDef.GraphicDef.DecalDef;
 using static Scripts.Structure.WeaponDefinition.AmmoDef.DamageScaleDef.DamageTypes.Damage;
+using static Scripts.Structure.WeaponDefinition.ProjectileFlags;
 
 namespace Scripts
 { // Don't edit above this line
@@ -69,6 +70,42 @@ namespace Scripts
                                   // It should be noted that this does NOT subtract the heat, use AmmoDef.AllowNegativeHeatModifier to subtract the desired amount.
             NpcSafe = false, // This is you tell npc moders that your ammo was designed with them in mind, if they tell you otherwise set this to false.
             NoGridOrArmorScaling = true, // If you enable this you can remove the damagescale section entirely.
+
+            // Thes are the "flags" that PDCs use to filter what projectiles they can shoot down (listed in Targeting.ProjectileThreats)
+            // This is where you set the Custom## flags used there for more filtering
+            // Alternatively, you can force enable the automatically set flags by listing them here, ie. labeling a Smart with approaches meant to be a drone as IsDrone
+            // You cannot forcefully disable flags
+            ProjectileFlagsOverride = new ProjectileFlags[]
+            {
+                Invalid,
+                //Custom01, Custom02, //... custom## ... Custom20
+                //AllCustom, // can be used in place of writing all 20 custom flags if you want all of them set for some reason
+
+                // other values that you can override here:
+                //IsDumb, // - Automatically set if the projectile guidance is None
+                //IsSmart, // - Automatically set if the projectile guidance is Smart
+                //IsDrone, // - Automatically set if the projectile guidance is DroneAdvanced
+                //IsMine, // - Automatically set if the projectile is one of the Mine guidance types
+                //IsTravelTo, // - Automatically set if the projectile guidance is TravelTo
+
+                //NoEwar, // - Automatically set if Ewar.Enable = false
+                //EwarEffect, // - Automatically set if Ewar.Enable = true and Ewar.Mode = Effect
+                //EwarField, // - Automatically set if Ewar.Enable = true and Ewar.Mode = Field
+                //Ewar, // - Equivalent to writing `EwarEffect, EwarField,`
+
+                //NonExplosive, // - Automatically set if ByBlockHit.Enable = false and EndOfLife.Enable = false
+                //BBHExplosive, // - Automatically set if ByBlockHit.Enable = true
+                //EOLExplosive, // - Automatically set if EndOfLife.Enable = true
+                //Explosive, // - Equivalent to writing `BBHExplosive, EOLExplosive,`
+
+                //NoFragments, // - Automatically set if the ammo def does not have a fragment defined
+                //HasFragments, // - Automatically set if the ammo def has a fragment defined
+
+                //AffectedByAntiSmarts, // - Automatically set if IsSmart = true and Trajectory.Smarts.IgnoreAntiSmarts = true
+                //IgnoresAntiSmarts, // - Automatically set if IsSmart = true and Trajectory.Smarts.IgnoreAntiSmarts = false
+
+                //All, // - Equivalent to writing out every flag on the list (and unused bits). Really not recommended
+            },
             Sync = new SynchronizeDef
             {
                 Full = false, // Use only on PD-killable (guided) projectiles that need to be replicated precisely on the client. It increases network traffic. When the projectile is fired (according to local game states), the clients don't locally spawn it, and instead, the server sends spawn packets to all clients, which spawns it exactly where the server spawned it. This also attaches a network identity to the projectile, allowing further replication, which you can control below.

--- a/Data/Scripts/CoreParts/script/Structure.cs
+++ b/Data/Scripts/CoreParts/script/Structure.cs
@@ -1,5 +1,7 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel;
+using KeenSoftwareHouse.Library.Extensions;
 using ProtoBuf;
 using VRageMath;
 
@@ -212,6 +214,132 @@ namespace Scripts
             [ProtoMember(6)] internal string ModPath;
             [ProtoMember(7)] internal Dictionary<string, UpgradeValues[]> Upgrades;
 
+            [Flags]
+            [Serializable]
+            public enum ProjectileFlags : ulong
+            {
+                /// <summary>
+                /// By default set to All on weapons, ammo defs are set based on stats below if a definition is recieved with this for backwards compat.
+                /// </summary>
+                Invalid = 0,
+
+                /// <summary>
+                /// Custom flags for modders
+                /// </summary>
+                Custom01 = 1uL << 0,
+                Custom02 = 1uL << 1,
+                Custom03 = 1uL << 2,
+                Custom04 = 1uL << 3,
+                Custom05 = 1uL << 4,
+                Custom06 = 1uL << 5,
+                Custom07 = 1uL << 6,
+                Custom08 = 1uL << 7,
+                Custom09 = 1uL << 8,
+                Custom10 = 1uL << 9,
+                Custom11 = 1uL << 10,
+                Custom12 = 1uL << 11,
+                Custom13 = 1uL << 12,
+                Custom14 = 1uL << 13,
+                Custom15 = 1uL << 14,
+                Custom16 = 1uL << 15,
+                Custom17 = 1uL << 16,
+                Custom18 = 1uL << 17,
+                Custom19 = 1uL << 18,
+                Custom20 = 1uL << 19,
+
+                /// <summary>
+                /// Automatically set if the projectile guidance is not, Smart, Drone, or Mine (aka either None or TravelTo)
+                /// </summary>
+                IsDumb = 1uL << 20,
+                /// <summary>
+                /// Automatically set if the projectile guidance is Smart
+                /// </summary>
+                IsSmart = 1uL << 21,
+                /// <summary>
+                /// Automatically set if the projectile guidance is DroneAdvanced
+                /// </summary>
+                IsDrone = 1uL << 22,
+                /// <summary>
+                /// Automatically set if the projectile guidance is a Mine
+                /// </summary>
+                IsMine = 1uL << 23,
+                /// <summary>
+                /// // Automatically set if the projectile is TravelTo
+                /// </summary>
+                IsTravelTo = 1uL << 24,
+                /// <summary>
+                /// value for backwards compat when IgnoreDumbProjectiles = true
+                /// </summary>
+                IgnoreDumbProjectiles = IsSmart | IsDrone,
+
+                /// <summary>
+                /// Automatically set if Ewar.Enable = false
+                /// </summary>
+                NoEwar = 1uL << 25,
+                /// <summary>
+                /// Automatically set if Ewar.Enable = true and Ewar.Mode = Effect
+                /// </summary>
+                EwarEffect = 1uL << 26,
+                /// <summary>
+                /// Automatically set if Ewar.Enable = true and Ewar.Mode = Field
+                /// </summary>
+                EwarField = 1uL << 27,
+                /// <summary>
+                /// Value representing Ewar.Enable = true
+                /// </summary>
+                Ewar = EwarEffect | EwarField,
+
+                /// <summary>
+                /// Automatically set if ByBlockHit.Enable = false and EndOfLife.Enable = false
+                /// </summary>
+                NonExplosive = 1uL << 28,
+                /// <summary>
+                /// Automatically set if ByBlockHit.Enable = true
+                /// </summary>
+                BBHExplosive = 1uL << 29,
+                /// <summary>
+                /// Automatically set if EndOfLife.Enable = true
+                /// </summary>
+                EOLExplosive = 1uL << 30,
+                /// <summary>
+                /// Value representing ByBlockHit.Enable = true or EndOfLife.Enable = true
+                /// </summary>
+                Explosive = BBHExplosive | EOLExplosive,
+
+                /// <summary>
+                /// Automatically set if the ammo def does not have a fragment defined
+                /// </summary>
+                NoFragments = 1uL << 31,
+                /// <summary>
+                /// Automatically set if the ammo def has a fragment defined
+                /// </summary>
+                HasFragments = 1uL << 32,
+
+                /// <summary>
+                /// Automatically set if IsSmart = true and Trajectory.Smarts.IgnoreAntiSmarts = false
+                /// </summary>
+                IgnoresAntiSmarts = 1uL << 33,
+                /// <summary>
+                /// Automatically set if IsSmart = true and Trajectory.Smarts.IgnoreAntiSmarts = true
+                /// </summary>
+                AffectedByAntiSmarts = 1uL << 34,
+
+                // room for more if needed
+                // note that bit order matters for UI - larger values will be listed lower
+                // because of this adding more Custom variables is difficult if you want them to be grouped with the other Custom variables
+
+                /// <summary>
+                /// All ones
+                /// </summary>
+                All = ~Invalid,
+
+                /// <summary>
+                /// Value representing any of the custom flags
+                /// </summary>
+                AllCustom = Custom01 | Custom02 | Custom03 | Custom04 | Custom05 | Custom06 | Custom07 | Custom08 | Custom09 | Custom10 |
+                            Custom11 | Custom12 | Custom13 | Custom14 | Custom15 | Custom16 | Custom17 | Custom18 | Custom19 | Custom20,
+            }
+
             [ProtoContract]
             public struct ModelAssignmentsDef
             {
@@ -292,7 +420,29 @@ namespace Scripts
                 [ProtoMember(24)] internal bool AllowSwitchTargetPriority;
                 [ProtoMember(25)] internal bool AllowFireDistribution;
                 [ProtoMember(26)] internal bool AdvancedFireDistribution;
+                [ProtoMember(27)] internal ulong ProjectileThreatsInternal; // ulong is needed or ProtoBuf throws a fit :(
+                [ProtoIgnore]
+                internal ProjectileFlags[] ProjectileThreats
+                {
+                    set
+                    {
+                        ProjectileThreatsInternal = (ulong)ProjectileFlags.Invalid;
+                        foreach (var flag in value)
+                        {
+                            if (flag == ProjectileFlags.Invalid)
+                            {
+                                ProjectileThreatsInternal = (ulong)ProjectileFlags.Invalid;
+                                return;
+                            }
+
+                            ProjectileThreatsInternal |= (ulong)flag;
+                        }
+                    }
+                }
+                [ProtoMember(28)] internal bool RequireAllProjectileThreats;
+
                 
+
                 [ProtoContract]
                 public struct CommunicationDef
                 {
@@ -550,6 +700,55 @@ namespace Scripts
                     [ProtoMember(8)] internal bool DisableSupportingPD;
                     [ProtoMember(9)] internal bool ProhibitShotDelay;
                     [ProtoMember(10)] internal bool ProhibitBurstCount;
+                    [ProtoMember(11)] internal ProjectileFlagsToggleDef UiFlagsToggle;
+
+                    [ProtoContract]
+                    public struct ProjectileFlagsToggleDef
+                    {
+                        [ProtoMember(1)] internal bool Enable;
+                        [ProtoMember(2)] internal ulong ProjectileThreatsTogglesInternal; // ulong is needed or ProtoBuf throws a fit :(
+                        [ProtoIgnore]
+                        internal ProjectileFlags[] ProjectileThreatToggles
+                        {
+                            set
+                            {
+                                ProjectileThreatsTogglesInternal = (ulong)ProjectileFlags.Invalid;
+                                foreach (var flag in value)
+                                {
+                                    if (flag == ProjectileFlags.Invalid)
+                                    {
+                                        ProjectileThreatsTogglesInternal = (ulong)ProjectileFlags.Invalid;
+                                        return;
+                                    }
+
+                                    ProjectileThreatsTogglesInternal |= (ulong)flag;
+                                }
+                            }
+                        }
+
+                        [ProtoMember(3)] internal string Custom01DisplayName;
+                        [ProtoMember(4)] internal string Custom02DisplayName;
+                        [ProtoMember(5)] internal string Custom03DisplayName;
+                        [ProtoMember(6)] internal string Custom04DisplayName;
+                        [ProtoMember(7)] internal string Custom05DisplayName;
+                        [ProtoMember(8)] internal string Custom06DisplayName;
+                        [ProtoMember(9)] internal string Custom07DisplayName;
+                        [ProtoMember(10)] internal string Custom08DisplayName;
+                        [ProtoMember(11)] internal string Custom09DisplayName;
+                        [ProtoMember(12)] internal string Custom10DisplayName;
+                        [ProtoMember(13)] internal string Custom11DisplayName;
+                        [ProtoMember(14)] internal string Custom12DisplayName;
+                        [ProtoMember(15)] internal string Custom13DisplayName;
+                        [ProtoMember(16)] internal string Custom14DisplayName;
+                        [ProtoMember(17)] internal string Custom15DisplayName;
+                        [ProtoMember(18)] internal string Custom16DisplayName;
+                        [ProtoMember(19)] internal string Custom17DisplayName;
+                        [ProtoMember(20)] internal string Custom18DisplayName;
+                        [ProtoMember(21)] internal string Custom19DisplayName;
+                        [ProtoMember(22)] internal string Custom20DisplayName;
+
+                        [ProtoMember(23)] internal bool RequireAllProjectileThreatsToggle;
+                    }
                 }
 
 
@@ -686,6 +885,25 @@ namespace Scripts
                 [ProtoMember(34)] internal bool IgnoreGrids;
                 [ProtoMember(35)] internal bool AllowNegativeHeatModifier;
                 [ProtoMember(36)] internal int HeatNeededToFire;
+                [ProtoMember(37)] internal ulong ProjectileFlagsInternal; // ulong is needed or ProtoBuf throws a fit :(
+                [ProtoIgnore]
+                internal ProjectileFlags[] ProjectileFlagsOverride
+                {
+                    set
+                    {
+                        ProjectileFlagsInternal = (ulong)ProjectileFlags.Invalid;
+                        foreach (var flag in value)
+                        {
+                            if (flag == ProjectileFlags.Invalid)
+                            {
+                                ProjectileFlagsInternal = (ulong)ProjectileFlags.Invalid;
+                                return;
+                            }
+
+                            ProjectileFlagsInternal |= (ulong)flag;
+                        }
+                    }
+                }
 
                 [ProtoContract]
                 public struct SynchronizeDef


### PR DESCRIPTION
# Changes
- Added enum `ProjectileFlags : ulong` to `WeaponDefinition`
  - A set of flags given to every projectile in order to allow different PDCs to target different projectiles
- Added `ulong ProjectileThreatsInternal` to `WeaponDefinition.TargetingDef`
- Added setter `ProjectileFlags[] ProjectileThreats` to `WeaponDefinition.TargetingDef`
  - This only sets `TargetingDef.ProjectileThreatsInternal` and is used on the frontend template cs file to keep inline with the enum arrays
  - The list of flags that the given PDC is allowed to target; by default it can target the projectile if it has atleast one flag
- Added `bool RequireAllProjectileThreats`
   - This changes above behavior to only allow targeting projectiles with ALL of the listed flags
- Added  `ulong ProjectileFlagsInternal` to `WeaponDefinition.AmmoDef`
- Added  setter `ProjectileFlags[] ProjectileFlagsOverride` to `WeaponDefinition.AmmoDef`
  - This only sets `AmmoDef.ProjectileThreatsInternal` and is used on the frontend template cs file to keep inline with the enum arrays
  - Sets any listed flags for the given projectile, and can be used with non Custom flags
- Added struct `ProjectileFlagsToggleDef`, added `ProjectileFlagsToggleDef UiFlagsToggle` to WeaponDefinition.HardpointDef.UiDef
   - `bool Enable`
      - Allows the user to control the flags listed in `ProjectileThreatToggles` via UI. These will overwrite what is in Targeting to whatever the user is set to. Any listed here will default to TRUE
   - `ulong ProjectileThreatsTogglesInternal`
   - ` ProjectileFlags[] ProjectileThreatToggles`
   - `bool RequireAllProjectileThreatsToggle`
      - Allows the user to control `RequireAllProjectileThreats`. Defaults to FALSE
   - 20x `string CustomXXDisplayName`, where XX ranges from `01` to `20` 
      - Allows the modder to set custom names for custom flags to be less confusing for users.
      - Note that these ARE NOT standardized between mods

- Soft removed `WeaponDefinition.Targeting.IgnoreDumbProjectiles` (removed from the template definition only)

# Implementation notes:
- `ProjectileFlags` still has many free bits to expand to later, although adding more Custom flags is going to be difficult once its public as Custom flags are listed first, and UI display lists by least to greatest bits; any new Custom flags will need to be appended and so will be put at the bottom of the list.
- This should be fully usable with PD fire distribution without anything failing
- `ProjectileFlags` should NEVER be updated mid flight!
- When serializing `ProjectileFlags`, it is necessary to convert to a `ulong` or protobuf throws an exception

# (put everything below on the wiki somewhere)
Consider this an extension (and depreciation of) `IgnoreDumbProjectiles`

`ProjectileFlags` are a set of flags assigned to each projectile, some of which are automatically added like `IsSmart` for smarts, and others which are fully custom (`Custom01`-20). The automatically assigned ones can also be manually assigned to any projectile, useful in for example designating a Smart as `IsDrone` due to having drone-like behavior.

Note that `CustomXX` flags can vary in meaning from mod to mod depending on the author due to them being custom!

These flags are then used by turrets to filter out targets. `Targeting.ProjectileThreats` define hardcoded flags that a projectile needs in order to target, with it being OR/AND based on `RequireAllProjectileThreats`'s value. OR means a projectile has at least one of the given flags, AND means the projectile has at least all of them.

`Hardpont.Ui.UiFlagsToggle` defines various settings related to allowing individual turrets to have user defined settings for this. Any `ProjectileThreatToggles` will override the given flag regardless of `Targeting.ProjectileThreats` to what the user decides. 
`RequireAllProjectileThreatsToggle` allows the user to toggle `RequireAllProjectileThreats` in the UI, while the `CustomXXDisplayNames` allow modders to set what the user facing name of each Custom flag is, and should ideally be standardized on a per mod, or per curated mod-list for server admins, basis.

UI Features require advanced settings to be shown.

Image of all the flags minus some of custom ones (the ... is Custom19 renamed)
<img width="461" height="984" alt="image" src="https://github.com/user-attachments/assets/388d4ca3-255e-4bae-8bf3-3f22786ef04d" />
Note that technically a PDC setup this way, due to `Use And Behavior`, will not actually fire at anything as there are conflicting flags, *unless* a modder has manually assigned a projectile said flags.

Image of renamed custom flags + `IsDrone`
<img width="506" height="606" alt="image" src="https://github.com/user-attachments/assets/3662dada-4156-4cc3-b5f9-5e3e0d409627" />
Note that I've elected to have Guided Missiles as a custom flag instead of using `IsSmart` because the drones I'm using are Smart + approach based, and need to be differentiated. This is not necessary if you only have missiles/torpedoes and no drones.