### PR TITLE
Add a Projectile Tag system for PD targeting and more

### DIFF
--- a/Data/Scripts/CoreParts/Armor.cs
+++ b/Data/Scripts/CoreParts/Armor.cs
@@ -5,6 +5,12 @@ namespace Scripts {
         // Don't edit above this line
         ArmorDefinition Armor1 => new ArmorDefinition
         {
+            // If there are multiple definitions with the same armor subtype ID (like say someone is adjusting stats of another's mod), then the definition with the highest priority will be loaded.
+            // For people making their own mod, its recommended to leave this at zero.
+            // For people MODIFYING other people's mod, its recommended to set this at anything greater than zero (ie. 1) so your changes override the original mod, and list that mod as a dependency.
+            // This effectively allows mod adjuster-like behavior without relying on mod load order, although the entire definition must be copied for it to work properly
+            //  - those modifying stats can just have the definitions in their place w/o copying any models, sbc files, or sounds to the modified mod.
+            DefinitionPriority = 0,
             SubtypeIds = new[] {
                 "Durasteel",
                 "DurasteelSlope",

--- a/Data/Scripts/CoreParts/ArmorSupport1a.cs
+++ b/Data/Scripts/CoreParts/ArmorSupport1a.cs
@@ -24,6 +24,12 @@ namespace Scripts {
             },
             HardPoint = new HardPointDef
             {
+                // If there are multiple definitions with the same part name & subtype ID (like say someone is adjusting stats of another's mod), then the definition with the highest priority will be loaded.
+                // For people making their own mod, its recommended to leave this at zero.
+                // For people MODIFYING other people's mod, its recommended to set this at anything greater than zero (ie. 1) so your changes override the original mod, and list that mod as a dependency.
+                // This effectively allows mod adjuster-like behavior without relying on mod load order, although the entire definition must be copied for it to work properly
+                //  - those modifying stats can just have the definitions in their place w/o copying any models, sbc files, or sounds to the modified mod.
+                DefinitionPriority = 0,
                 PartName = "ArmorSupport1a", // name of weapon in terminal, should be unique for each weapon definition that shares a SubtypeId (i.e. multiweapons)
 
                 Ui = new UiDef

--- a/Data/Scripts/CoreParts/MasterConfig.cs
+++ b/Data/Scripts/CoreParts/MasterConfig.cs
@@ -14,6 +14,8 @@ namespace Scripts
             ArmorDefinitions(Armor1, Armor2);
             SupportDefinitions(ArmorEnhancer1A);
             UpgradeDefinitions(Upgrade75a, Upgrade75b);
+            ProjectileTags(ExampleTag1Def);
+            ProjectileTagAssignments(ExampleTagAssignments);
         }
     }
 }

--- a/Data/Scripts/CoreParts/MasterConfig.cs
+++ b/Data/Scripts/CoreParts/MasterConfig.cs
@@ -15,7 +15,7 @@ namespace Scripts
             SupportDefinitions(ArmorEnhancer1A);
             UpgradeDefinitions(Upgrade75a, Upgrade75b);
             ProjectileTags(ExampleTag1Def);
-            ProjectileTagAssignments(ExampleTagAssignments);
+            ProjectileTagAssignments(TagAssignments);
         }
     }
 }

--- a/Data/Scripts/CoreParts/ProjectileTags.cs
+++ b/Data/Scripts/CoreParts/ProjectileTags.cs
@@ -9,53 +9,66 @@ namespace Scripts
         // Don't edit above this line
         ProjectileTagDefinition ExampleTag1Def => new ProjectileTagDefinition
         {
+            // This is where you define any projectile tags for your mod.
+            // They are defined in two steps, a namespace which is the first part of the tag and is consistent for every tag defined,
+            // and the ID itself. Think of this like a type ID and subtype ID pair, except you also have full reign over your type ID, it just needs to be consistent across your mod.
+
             Namespace = new Tag
             {
-                ID = "examplecoreparts", // internal name
-                PublicName = "Your Mod Name Here", // Public facing name
+                ID = "examplecoreparts", // What will actually be used in definitions
+                PublicName = "Your Mod Name Here", // Public facing name for UI
             },
+            // If there are multiple definitions with the same namespace & subtype ID (like say someone is adjusting stats of another's mod), then the definition with the highest priority will be loaded.
+            // For people making their own weapon mod, its recommended to leave this at zero.
+            // For people MODIFYING other people's mod, its recommended to set this at anything greater than zero (ie. 1) so your changes override the original mod, and list that mod as a dependency.
+            // This effectively allows mod adjuster-like behavior without relying on mod load order, although the entire definition must be copied for it to work properly
+            //  - those modifying stats can just have the definitions in their place w/o copying any models, sbc files, or sounds to the modified mod.
             DefinitionPriority = 0,
             Tags = new[]
             {
                 new Tag 
                 {
-                    ID = "cannon", 
-                    PublicName = "Cannon"
+                    ID = "cannon", // What will actually be used in definitions
+                    PublicName = "Cannon" // Public facing name for UI
                 },
                 new Tag 
                 {
-                    ID = "stealth",
-                    PublicName = "Stealth Projectile"
+                    ID = "stealth", // What will actually be used in definitions
+                    PublicName = "Stealth Projectile" // Public facing name for UI
                 },
                 new Tag 
                 {
-                    ID = "small",
-                    PublicName = "Small"
+                    ID = "small", // What will actually be used in definitions
+                    PublicName = "Small" // Public facing name for UI
                 },
                 new Tag 
                 {
-                    ID = "large",
-                    PublicName = "Large"
+                    ID = "large", // What will actually be used in definitions
+                    PublicName = "Large" // Public facing name for UI
                 },
             },
         };
 
-        ProjectileTagAssignment[] ExampleTagAssignments => new[]
+        ProjectileTagAssignment[] TagAssignments => new[]
         {
+            // This is where you can assign tags to any ammo type. Neither tag nor ammo type needs to be from your mod.
+            // Tags here take the form of `namespace:tag`, so something like `wc:smart` or `coreparts:ammo1`
+
+            // 
             new ProjectileTagAssignment
             {
-                Tag = "yourmodhere:stealth",
+                Tag = "yourmodhere:stealth", // Tag in the form of `namespace:tag`, and will be applied to all ammo names with the an AmmoRound name listed below
                 ProjectileAmmoNames = new[]
                 {
-                    "Ammo 1",
+                    "Ammo 1", // name of the ammo you want to apply the above tag too. Uses the AmmoRound field
                 },
             },
             new ProjectileTagAssignment
             {
-                Tag = "yourmodhere:small",
+                Tag = "yourmodhere:small", // Tag in the form of `namespace:tag`, and will be applied to all ammo names with the an AmmoRound name listed below
                 ProjectileAmmoNames = new[]
                 {
-                    "Ammo 1",
+                    "Ammo 1", // name of the ammo you want to apply the above tag too. Uses the AmmoRound field
                 },
             }
         };

--- a/Data/Scripts/CoreParts/ProjectileTags.cs
+++ b/Data/Scripts/CoreParts/ProjectileTags.cs
@@ -1,0 +1,63 @@
+﻿using static Scripts.Structure;
+using static Scripts.Structure.ProjectileTagDefinition;
+using static Scripts.Structure.ProjectileTagAssignment;
+
+namespace Scripts
+{
+    partial class Parts
+    {
+        // Don't edit above this line
+        ProjectileTagDefinition ExampleTag1Def => new ProjectileTagDefinition
+        {
+            Namespace = new Tag
+            {
+                ID = "examplecoreparts", // internal name
+                PublicName = "Your Mod Name Here", // Public facing name
+            },
+            DefinitionPriority = 0,
+            Tags = new[]
+            {
+                new Tag 
+                {
+                    ID = "cannon", 
+                    PublicName = "Cannon"
+                },
+                new Tag 
+                {
+                    ID = "stealth",
+                    PublicName = "Stealth Projectile"
+                },
+                new Tag 
+                {
+                    ID = "small",
+                    PublicName = "Small"
+                },
+                new Tag 
+                {
+                    ID = "large",
+                    PublicName = "Large"
+                },
+            },
+        };
+
+        ProjectileTagAssignment[] ExampleTagAssignments => new[]
+        {
+            new ProjectileTagAssignment
+            {
+                Tag = "yourmodhere:stealth",
+                ProjectileAmmoNames = new[]
+                {
+                    "Ammo 1",
+                },
+            },
+            new ProjectileTagAssignment
+            {
+                Tag = "yourmodhere:small",
+                ProjectileAmmoNames = new[]
+                {
+                    "Ammo 1",
+                },
+            }
+        };
+    }
+}

--- a/Data/Scripts/CoreParts/Upgrade75aPart.cs
+++ b/Data/Scripts/CoreParts/Upgrade75aPart.cs
@@ -22,6 +22,12 @@ namespace Scripts {
             },
             HardPoint = new HardPointDef
             {
+                // If there are multiple definitions with the same part name & subtype ID (like say someone is adjusting stats of another's mod), then the definition with the highest priority will be loaded.
+                // For people making their own mod, its recommended to leave this at zero.
+                // For people MODIFYING other people's mod, its recommended to set this at anything greater than zero (ie. 1) so your changes override the original mod, and list that mod as a dependency.
+                // This effectively allows mod adjuster-like behavior without relying on mod load order, although the entire definition must be copied for it to work properly
+                //  - those modifying stats can just have the definitions in their place w/o copying any models, sbc files, or sounds to the modified mod.
+                DefinitionPriority = 0,
                 PartName = "Upgrade75a", // name of weapon in terminal
 
                 Ui = new UiDef

--- a/Data/Scripts/CoreParts/Upgrade75bPart.cs
+++ b/Data/Scripts/CoreParts/Upgrade75bPart.cs
@@ -24,6 +24,12 @@ namespace Scripts
             },
             HardPoint = new HardPointDef
             {
+                // If there are multiple definitions with the same part name & subtype ID (like say someone is adjusting stats of another's mod), then the definition with the highest priority will be loaded.
+                // For people making their own mod, its recommended to leave this at zero.
+                // For people MODIFYING other people's mod, its recommended to set this at anything greater than zero (ie. 1) so your changes override the original mod, and list that mod as a dependency.
+                // This effectively allows mod adjuster-like behavior without relying on mod load order, although the entire definition must be copied for it to work properly
+                //  - those modifying stats can just have the definitions in their place w/o copying any models, sbc files, or sounds to the modified mod.
+                DefinitionPriority = 0,
                 PartName = "Upgrade75b", // name of weapon in terminal
 
                 Ui = new UiDef

--- a/Data/Scripts/CoreParts/Weapon75Part.cs
+++ b/Data/Scripts/CoreParts/Weapon75Part.cs
@@ -5,6 +5,7 @@ using static Scripts.Structure.WeaponDefinition.HardPointDef;
 using static Scripts.Structure.WeaponDefinition.HardPointDef.Prediction;
 using static Scripts.Structure.WeaponDefinition.TargetingDef.BlockTypes;
 using static Scripts.Structure.WeaponDefinition.TargetingDef.Threat;
+using static Scripts.Structure.WeaponDefinition.TargetingDef.WhitelistSystem;
 using static Scripts.Structure.WeaponDefinition.TargetingDef;
 using static Scripts.Structure.WeaponDefinition.TargetingDef.CommunicationDef.Comms;
 using static Scripts.Structure.WeaponDefinition.TargetingDef.CommunicationDef.SecurityMode;
@@ -12,9 +13,8 @@ using static Scripts.Structure.WeaponDefinition.HardPointDef.HardwareDef;
 using static Scripts.Structure.WeaponDefinition.HardPointDef.HardwareDef.HardwareType;
 using static Scripts.Structure.WeaponDefinition.HardPointDef.LoadingDef;
 using static Scripts.Structure.WeaponDefinition.HardPointDef.UiDef;
-using static Scripts.Structure.WeaponDefinition.ProjectileFlags;
 
-namespace Scripts {   
+namespace Scripts {
     partial class Parts {
         // Don't edit above this line
         WeaponDefinition Weapon75 => new WeaponDefinition
@@ -50,47 +50,32 @@ namespace Scripts {
                     Grids, Projectiles // Types of threat to engage: Grids, Projectiles, Characters, Meteors, Neutrals, ScanRoid, ScanPlanet, ScanFriendlyCharacter, ScanFriendlyGrid, ScanEnemyCharacter, ScanEnemyGrid, ScanNeutralCharacter, ScanNeutralGrid, ScanUnOwnedGrid, ScanOwnersGrid
                            // Grids are both LG and SG. Use Hardpoint.Other.ProhibitLGTargeting and Use Hardpoint.Other.ProhibitSGTargeting to further differentiate
                 },
-                // ProjectileThreats you to further specify what Projectiles to target if Projectiles is listed above.
-                // This allows you to fine tune what your PDC will fire at, be it Dumb only, Smart only, or more specifically Explosive Smart projectiles, or Smarts that IgnoreAntiSmarts
-                // This also comes with custom flags that are only set in ammo definitions
+                // ProjectileTags you to further specify what Projectiles to target if Projectiles is listed above.
+                // These tags are set in ProjectileTags.cs, and are futher elaborated there.
+                // This allows you to fine tune what your PDC will fire at.
                 // This is NOT a priority system, items higher on the list are not prioritized whatosever!
-                // Note: this depreciates the IgnoreDumbProjectiles setting, if you want that back then put it in the array as seen at the bottom.
-                // Note: This operates on an OR system by default (RequireExactProjectileThreats = true changes this to an AND system), ie. if you list both IsDumb and IsSmart, then it will basically target any projectile.
-                // Note: Atleast one value is needed or this fails to compile.
-                ProjectileThreats = new[] {
-                    IsDumb, // - Automatically set if the projectile guidance is None
-                    IsSmart, // - Automatically set if the projectile guidance is Smart
-                    IsDrone, // - Automatically set if the projectile guidance is DroneAdvanced
-                    IsMine, // - Automatically set if the projectile is one of the Mine guidance types
-                    IsTravelTo, // - Automatically set if the projectile guidance is TravelTo
+                // Note: Atleast one value is needed or this fails to compile. The defaults are not really used.
+                // Note: Consider this an extension (and depreciation) of IgnoreDumbProjectiles. If you want to emulate IgnoreDumbProjectiles behavior, add the tags "wc:smart" and "wc:drone" to the list and set ProjectileTagsMeaning to Whitelist
+                ProjectileTagsList = new[]
+                {
+                    "namespace1:tag1",
+                    "namespace1:tag2",
+                    "namespace2:tag1",
+                    "namespace2:tag2",
 
-                    NoEwar, // Set if Ewar.Enable = false
-                    EwarEffect, // Set if Ewar.Enable = true and Ewar.Mode = Effect
-                    EwarField, // Set if Ewar.Enable = true and Ewar.Mode = Field
-                    Ewar, // Equivalent to writing `EwarEffect, EwarField,`
-
-                    NonExplosive, // Set if ByBlockHit.Enable = false and EndOfLife.Enable = false
-                    BBHExplosive, // Set if ByBlockHit.Enable = true
-                    EOLExplosive, // Set if EndOfLife.Enable = true
-                    Explosive, // Equivalent to writing `BBHExplosive, EOLExplosive,`
-
-                    NoFragments, // Set if the ammo def does not have a fragment defined
-                    HasFragments, // Set if the ammo def has a fragment defined
-
-                    AffectedByAntiSmarts, // Set if IsSmart = true and Trajectory.Smarts.IgnoreAntiSmarts = true
-                    IgnoresAntiSmarts, //  Set if IsSmart = true and Trajectory.Smarts.IgnoreAntiSmarts = false
-
-                    // Custom flags are flags set manually in AmmoDef.ProjectileFlagsOverride, and can be used to further specify things
-                    // Ie. using Custom01 for cannons, Custom02 for railguns, Custom03 for rockets, etc.
-                    // These can be somewhat wonky between differing modpacks, so recommend for server admins only really
-                    Custom01, Custom02, //... Custom## ... Custom20
-                    //AllCustom, // can be used in place of writing all 20 custom flags if you want all of them set for some reason
-
-                    All, // Equivalent to writing out every flag on the list (and invalid bits)
-                    
-                    //IgnoreDumbProjectiles // Equivalent to the old IgnoreDumbProjectiles setting
+                    // These five are automatically set tags by weaponcore according to their guidance type. Uncomment them to use
+                    //"wc:dumb", // set if GuidanceType == None
+                    //"wc:smart", // set if GuidanceType == Smart
+                    //"wc:drone", // set if GuidanceType == DroneAdvanced
+                    //"wc:mine", // set if GuidanceType is any of the mine types
+                    //"wc:travelto", // set if GuidanceType == TravelTo
                 },
-                RequireAllProjectileThreats = false, // If true, only engages projectiles that have atleast all flags specified above. If false, engages any projectile that has at least one of the specified flags.
+                // This sets what ProjectileTagsList is interpeted as. Values:
+                // Blacklist - this weapon will NOT fire at any projectile if it has atleast one of the above tags
+                // WhitelistOr - this weapon will ONLY fire at a projectile if it has atleast one of the above tags
+                // WhitelistAnd - this weapon will ONLY fire at a projectile if it has ALL pf the above tags
+                // If you don't want to use this system, leave it on Blacklist!
+                ProjectileTagsMeaning = Blacklist,
                 SubSystems = new[] {
                     Thrust, Utility, Offense, Power, Production, Any, // Subsystem targeting priority: Offense, Utility, Power, Production, Thrust, Jumping, Steering, Any
                                                                       // Order matters! With the current setting weapons will target Thrust first, then Utility, then Offense, etc.
@@ -133,6 +118,12 @@ namespace Scripts {
             },
             HardPoint = new HardPointDef
             {
+                // If there are multiple definitions with the same part name & subtype ID (like say someone is adjusting stats of another's mod), then the definition with the highest priority will be loaded.
+                // For people making their own weapon mod, its recommended to leave this at zero.
+                // For people MODIFYING other people's mod, its recommended to set this at anything greater than zero (ie. 1).
+                // This effectively allows mod adjuster-like behavior without relying on mod load order, although the entire definition must be copied for it to work properly
+                //  - those modifying stats can just have the definitions in their place w/o copying any models, sbc files, or sounds to the modified mod.
+                DefinitionPriority = 0,
                 PartName = "Gatling", // Name of the weapon in terminal, should be unique for each weapon definition that shares a SubtypeId (i.e. multiweapons).
                 DeviateShotAngle = 0.2f, // Projectile inaccuracy in degrees.
                 DeviateShotAngleSGModifier = 0.4f, // Additional range of projectile inaccuracy added to DeviateShotAngle if the target is a small grid
@@ -155,75 +146,31 @@ namespace Scripts {
                     DisableSupportingPD = false, // If true, the supporting point defense terminal option will be removed and this weapon will only target projectiles targeting the construct it's placed on
                     ProhibitShotDelay = false, // If true, removes shot delay options for players.  This may be desirable for weapons that use heat or bursts as a balance mechanic and deliberately do not offer the ROF slider.
                     ProhibitBurstCount = false, // If true, removes burst shot count options for players.
-                    UiFlagsToggle = new ProjectileFlagsToggleDef
+                    UiSetTags = new UiSetTagsDef
                     {
-                        // Enabling this allows users to toggle projectile flags listed here.
-                        // User flags will take priority if they are set here with the above list in Targeting serving as defaults.
-                        // Ie. If IsDumb is listed in Targeting and here the user can toggle it on and off, and will default on
-                        //     If IsDumb is NOT listed in Targeting and here the user can toggle it on and off, and will default off
-                        //     If IsDumb is listed in Targeting and NOT here then it will be forced on
+                        // Enables user toggles for ProjectileTags
                         Enable = false,
-
-                        // ProjectileThreats you to further specify what Projectiles to target if Projectiles is listed above.
-                        // This allows you to fine tune what your PDC will fire at, be it Dumb only, Smart only, or more specifically Explosive Smart projectiles, or Smarts that IgnoreAntiSmarts
-                        // This also comes with custom flags that are only set in ammo definitions
+                        // ProjectileTags you to further specify what Projectiles to target if Projectiles is listed above.
+                        // These tags are set in ProjectileTags.cs, and are futher elaborated there.
+                        // This allows you to fine tune what your PDC will fire at.
                         // This is NOT a priority system, items higher on the list are not prioritized whatosever!
-                        // Listed ones will default true regardless of what is listed above
-                        ProjectileThreatToggles = new[] {
-                            IsDumb, // - Automatically set if the projectile guidance is None
-                            IsSmart, // - Automatically set if the projectile guidance is Smart
-                            IsDrone, // - Automatically set if the projectile guidance is DroneAdvanced
-                            IsMine, // - Automatically set if the projectile is one of the Mine guidance types
-                            IsTravelTo, // - Automatically set if the projectile guidance is TravelTo
+                        // Note: Atleast one value is needed or this fails to compile.
+                        ProjectileTagsList = new[]
+                        {
+                            "namespace1:tag1",
+                            "namespace1:tag2",
+                            "namespace2:tag1",
+                            "namespace2:tag2",
 
-                            //NoEwar, // Set if Ewar.Enable = false
-                            //EwarEffect, // Set if Ewar.Enable = true and Ewar.Mode = Effect
-                            //EwarField, // Set if Ewar.Enable = true and Ewar.Mode = Field
-                            //Ewar, // Equivalent to writing `EwarEffect, EwarField,`
-
-                            //NonExplosive, // Set if ByBlockHit.Enable = false and EndOfLife.Enable = false
-                            //BBHExplosive, // Set if ByBlockHit.Enable = true
-                            //EOLExplosive, // Set if EndOfLife.Enable = true
-                            //Explosive, // Equivalent to writing `BBHExplosive, EOLExplosive,`
-
-                            //NoFragments, // Set if the ammo def does not have a fragment defined
-                            //HasFragments, // Set if the ammo def has a fragment defined
-
-                            //AffectedByAntiSmarts, // Set if IsSmart = true and Trajectory.Smarts.IgnoreAntiSmarts = true
-                            //IgnoresAntiSmarts, //  Set if IsSmart = true and Trajectory.Smarts.IgnoreAntiSmarts = false
-
-                            // Custom flags are flags set manually in AmmoDef.ProjectileFlagsOverride, and can be used to further specify things
-                            // Ie. using Custom01 for cannons, Custom02 for railguns, Custom03 for rockets, etc.
-                            // Note that these flags on projectiles can change meaning from mod to mod! Recommended for server admins only, or if enough people decide what each flag is
-                            Custom01, Custom02, //... Custom## ... Custom20
-                            //AllCustom, // can be used in place of writing all 20 custom flags if you want all of them set for some reason
-
-                            //All, // Do not put here even if its technically a valid option, as it will set unused bits which WILL show up in the UI
+                            // These five are automatically set tags by weaponcore according to their guidance type. Uncomment them to use
+                            //"wc:dumb", // set if GuidanceType == None
+                            //"wc:smart", // set if GuidanceType == Smart
+                            //"wc:drone", // set if GuidanceType == DroneAdvanced
+                            //"wc:mine", // set if GuidanceType is any of the mine types
+                            //"wc:travelto", // set if GuidanceType == TravelTo
                         },
-                        RequireAllProjectileThreatsToggle = false, // Allow the user to toggle RequireAllProjectileThreats, and will default off regardless of what is listed above if true
-
-                        // Custom display names for the Custom01-Custom20 flags in the UI. Note that these flags on projectiles can change meaning from mod to mod!
-                        Custom01DisplayName = "",
-                        Custom02DisplayName = "",
-                        Custom03DisplayName = "",
-                        Custom04DisplayName = "",
-                        Custom05DisplayName = "",
-                        Custom06DisplayName = "",
-                        Custom07DisplayName = "",
-                        Custom08DisplayName = "",
-                        Custom09DisplayName = "",
-                        Custom10DisplayName = "",
-                        Custom11DisplayName = "",
-                        Custom12DisplayName = "",
-                        Custom13DisplayName = "",
-                        Custom14DisplayName = "",
-                        Custom15DisplayName = "",
-                        Custom16DisplayName = "",
-                        Custom17DisplayName = "",
-                        Custom18DisplayName = "",
-                        Custom19DisplayName = "",
-                        Custom20DisplayName = "",
-
+                        // This allows the user to set what ProjectileTagsList is interpeted as if true. Atm you cannot remove options from the list (Blacklist, WhitelistOr, WhitelistAnd)
+                        AllowUserWhitelistChange = false,
                     }
                 },
                 Ai = new AiDef

--- a/Data/Scripts/CoreParts/Weapon75Part.cs
+++ b/Data/Scripts/CoreParts/Weapon75Part.cs
@@ -121,8 +121,8 @@ namespace Scripts {
             HardPoint = new HardPointDef
             {
                 // If there are multiple definitions with the same part name & subtype ID (like say someone is adjusting stats of another's mod), then the definition with the highest priority will be loaded.
-                // For people making their own weapon mod, its recommended to leave this at zero.
-                // For people MODIFYING other people's mod, its recommended to set this at anything greater than zero (ie. 1).
+                // For people making their own mod, its recommended to leave this at zero.
+                // For people MODIFYING other people's mod, its recommended to set this at anything greater than zero (ie. 1) so your changes override the original mod, and list that mod as a dependency.
                 // This effectively allows mod adjuster-like behavior without relying on mod load order, although the entire definition must be copied for it to work properly
                 //  - those modifying stats can just have the definitions in their place w/o copying any models, sbc files, or sounds to the modified mod.
                 DefinitionPriority = 0,

--- a/Data/Scripts/CoreParts/Weapon75Part.cs
+++ b/Data/Scripts/CoreParts/Weapon75Part.cs
@@ -11,6 +11,8 @@ using static Scripts.Structure.WeaponDefinition.TargetingDef.CommunicationDef.Se
 using static Scripts.Structure.WeaponDefinition.HardPointDef.HardwareDef;
 using static Scripts.Structure.WeaponDefinition.HardPointDef.HardwareDef.HardwareType;
 using static Scripts.Structure.WeaponDefinition.HardPointDef.LoadingDef;
+using static Scripts.Structure.WeaponDefinition.HardPointDef.UiDef;
+using static Scripts.Structure.WeaponDefinition.ProjectileFlags;
 
 namespace Scripts {   
     partial class Parts {
@@ -45,15 +47,55 @@ namespace Scripts {
             Targeting = new TargetingDef
             {
                 Threats = new[] {
-                    Grids, // Types of threat to engage: Grids, Projectiles, Characters, Meteors, Neutrals, ScanRoid, ScanPlanet, ScanFriendlyCharacter, ScanFriendlyGrid, ScanEnemyCharacter, ScanEnemyGrid, ScanNeutralCharacter, ScanNeutralGrid, ScanUnOwnedGrid, ScanOwnersGrid
+                    Grids, Projectiles // Types of threat to engage: Grids, Projectiles, Characters, Meteors, Neutrals, ScanRoid, ScanPlanet, ScanFriendlyCharacter, ScanFriendlyGrid, ScanEnemyCharacter, ScanEnemyGrid, ScanNeutralCharacter, ScanNeutralGrid, ScanUnOwnedGrid, ScanOwnersGrid
                            // Grids are both LG and SG. Use Hardpoint.Other.ProhibitLGTargeting and Use Hardpoint.Other.ProhibitSGTargeting to further differentiate
                 },
+                // ProjectileThreats you to further specify what Projectiles to target if Projectiles is listed above.
+                // This allows you to fine tune what your PDC will fire at, be it Dumb only, Smart only, or more specifically Explosive Smart projectiles, or Smarts that IgnoreAntiSmarts
+                // This also comes with custom flags that are only set in ammo definitions
+                // This is NOT a priority system, items higher on the list are not prioritized whatosever!
+                // Note: this depreciates the IgnoreDumbProjectiles setting, if you want that back then put it in the array as seen at the bottom.
+                // Note: This operates on an OR system by default (RequireExactProjectileThreats = true changes this to an AND system), ie. if you list both IsDumb and IsSmart, then it will basically target any projectile.
+                // Note: Atleast one value is needed or this fails to compile.
+                ProjectileThreats = new[] {
+                    IsDumb, // - Automatically set if the projectile guidance is None
+                    IsSmart, // - Automatically set if the projectile guidance is Smart
+                    IsDrone, // - Automatically set if the projectile guidance is DroneAdvanced
+                    IsMine, // - Automatically set if the projectile is one of the Mine guidance types
+                    IsTravelTo, // - Automatically set if the projectile guidance is TravelTo
+
+                    NoEwar, // Set if Ewar.Enable = false
+                    EwarEffect, // Set if Ewar.Enable = true and Ewar.Mode = Effect
+                    EwarField, // Set if Ewar.Enable = true and Ewar.Mode = Field
+                    Ewar, // Equivalent to writing `EwarEffect, EwarField,`
+
+                    NonExplosive, // Set if ByBlockHit.Enable = false and EndOfLife.Enable = false
+                    BBHExplosive, // Set if ByBlockHit.Enable = true
+                    EOLExplosive, // Set if EndOfLife.Enable = true
+                    Explosive, // Equivalent to writing `BBHExplosive, EOLExplosive,`
+
+                    NoFragments, // Set if the ammo def does not have a fragment defined
+                    HasFragments, // Set if the ammo def has a fragment defined
+
+                    AffectedByAntiSmarts, // Set if IsSmart = true and Trajectory.Smarts.IgnoreAntiSmarts = true
+                    IgnoresAntiSmarts, //  Set if IsSmart = true and Trajectory.Smarts.IgnoreAntiSmarts = false
+
+                    // Custom flags are flags set manually in AmmoDef.ProjectileFlagsOverride, and can be used to further specify things
+                    // Ie. using Custom01 for cannons, Custom02 for railguns, Custom03 for rockets, etc.
+                    // These can be somewhat wonky between differing modpacks, so recommend for server admins only really
+                    Custom01, Custom02, //... Custom## ... Custom20
+                    //AllCustom, // can be used in place of writing all 20 custom flags if you want all of them set for some reason
+
+                    All, // Equivalent to writing out every flag on the list (and invalid bits)
+                    
+                    //IgnoreDumbProjectiles // Equivalent to the old IgnoreDumbProjectiles setting
+                },
+                RequireAllProjectileThreats = false, // If true, only engages projectiles that have atleast all flags specified above. If false, engages any projectile that has at least one of the specified flags.
                 SubSystems = new[] {
                     Thrust, Utility, Offense, Power, Production, Any, // Subsystem targeting priority: Offense, Utility, Power, Production, Thrust, Jumping, Steering, Any
                                                                       // Order matters! With the current setting weapons will target Thrust first, then Utility, then Offense, etc.
                 },
                 ClosestFirst = true, // Tries to pick closest targets first (blocks on grids, projectiles, etc...).
-                IgnoreDumbProjectiles = false, // Don't fire at non-smart projectiles.
                 LockedSmartOnly = false, // Only fire at smart projectiles that are locked on to parent grid.
                 MinimumDiameter = 0, // Minimum diameter of threat to engage.
                 MaximumDiameter = 0, // Maximum diameter of threat to engage; 0 = unlimited.
@@ -113,6 +155,76 @@ namespace Scripts {
                     DisableSupportingPD = false, // If true, the supporting point defense terminal option will be removed and this weapon will only target projectiles targeting the construct it's placed on
                     ProhibitShotDelay = false, // If true, removes shot delay options for players.  This may be desirable for weapons that use heat or bursts as a balance mechanic and deliberately do not offer the ROF slider.
                     ProhibitBurstCount = false, // If true, removes burst shot count options for players.
+                    UiFlagsToggle = new ProjectileFlagsToggleDef
+                    {
+                        // Enabling this allows users to toggle projectile flags listed here.
+                        // User flags will take priority if they are set here with the above list in Targeting serving as defaults.
+                        // Ie. If IsDumb is listed in Targeting and here the user can toggle it on and off, and will default on
+                        //     If IsDumb is NOT listed in Targeting and here the user can toggle it on and off, and will default off
+                        //     If IsDumb is listed in Targeting and NOT here then it will be forced on
+                        Enable = false,
+
+                        // ProjectileThreats you to further specify what Projectiles to target if Projectiles is listed above.
+                        // This allows you to fine tune what your PDC will fire at, be it Dumb only, Smart only, or more specifically Explosive Smart projectiles, or Smarts that IgnoreAntiSmarts
+                        // This also comes with custom flags that are only set in ammo definitions
+                        // This is NOT a priority system, items higher on the list are not prioritized whatosever!
+                        // Listed ones will default true regardless of what is listed above
+                        ProjectileThreatToggles = new[] {
+                            IsDumb, // - Automatically set if the projectile guidance is None
+                            IsSmart, // - Automatically set if the projectile guidance is Smart
+                            IsDrone, // - Automatically set if the projectile guidance is DroneAdvanced
+                            IsMine, // - Automatically set if the projectile is one of the Mine guidance types
+                            IsTravelTo, // - Automatically set if the projectile guidance is TravelTo
+
+                            //NoEwar, // Set if Ewar.Enable = false
+                            //EwarEffect, // Set if Ewar.Enable = true and Ewar.Mode = Effect
+                            //EwarField, // Set if Ewar.Enable = true and Ewar.Mode = Field
+                            //Ewar, // Equivalent to writing `EwarEffect, EwarField,`
+
+                            //NonExplosive, // Set if ByBlockHit.Enable = false and EndOfLife.Enable = false
+                            //BBHExplosive, // Set if ByBlockHit.Enable = true
+                            //EOLExplosive, // Set if EndOfLife.Enable = true
+                            //Explosive, // Equivalent to writing `BBHExplosive, EOLExplosive,`
+
+                            //NoFragments, // Set if the ammo def does not have a fragment defined
+                            //HasFragments, // Set if the ammo def has a fragment defined
+
+                            //AffectedByAntiSmarts, // Set if IsSmart = true and Trajectory.Smarts.IgnoreAntiSmarts = true
+                            //IgnoresAntiSmarts, //  Set if IsSmart = true and Trajectory.Smarts.IgnoreAntiSmarts = false
+
+                            // Custom flags are flags set manually in AmmoDef.ProjectileFlagsOverride, and can be used to further specify things
+                            // Ie. using Custom01 for cannons, Custom02 for railguns, Custom03 for rockets, etc.
+                            // Note that these flags on projectiles can change meaning from mod to mod! Recommended for server admins only, or if enough people decide what each flag is
+                            Custom01, Custom02, //... Custom## ... Custom20
+                            //AllCustom, // can be used in place of writing all 20 custom flags if you want all of them set for some reason
+
+                            //All, // Do not put here even if its technically a valid option, as it will set unused bits which WILL show up in the UI
+                        },
+                        RequireAllProjectileThreatsToggle = false, // Allow the user to toggle RequireAllProjectileThreats, and will default off regardless of what is listed above if true
+
+                        // Custom display names for the Custom01-Custom20 flags in the UI. Note that these flags on projectiles can change meaning from mod to mod!
+                        Custom01DisplayName = "",
+                        Custom02DisplayName = "",
+                        Custom03DisplayName = "",
+                        Custom04DisplayName = "",
+                        Custom05DisplayName = "",
+                        Custom06DisplayName = "",
+                        Custom07DisplayName = "",
+                        Custom08DisplayName = "",
+                        Custom09DisplayName = "",
+                        Custom10DisplayName = "",
+                        Custom11DisplayName = "",
+                        Custom12DisplayName = "",
+                        Custom13DisplayName = "",
+                        Custom14DisplayName = "",
+                        Custom15DisplayName = "",
+                        Custom16DisplayName = "",
+                        Custom17DisplayName = "",
+                        Custom18DisplayName = "",
+                        Custom19DisplayName = "",
+                        Custom20DisplayName = "",
+
+                    }
                 },
                 Ai = new AiDef
                 {

--- a/Data/Scripts/CoreParts/Weapon75Part.cs
+++ b/Data/Scripts/CoreParts/Weapon75Part.cs
@@ -55,7 +55,7 @@ namespace Scripts {
                 // This allows you to fine tune what your PDC will fire at.
                 // This is NOT a priority system, items higher on the list are not prioritized whatosever!
                 // Note: Atleast one value is needed or this fails to compile. The defaults are not really used.
-                // Note: Consider this an extension (and depreciation) of IgnoreDumbProjectiles. If you want to emulate IgnoreDumbProjectiles behavior, add the tags "wc:smart" and "wc:drone" to the list and set ProjectileTagsMeaning to Whitelist
+                // Note: Consider this an extension (and depreciation) of IgnoreDumbProjectiles. If you want to emulate IgnoreDumbProjectiles behavior w/ more tags, add the tags "wc:smart" and "wc:drone" to the list and set ProjectileTagsMeaning to Whitelist
                 ProjectileTagsList = new[]
                 {
                     "namespace1:tag1",
@@ -71,16 +71,18 @@ namespace Scripts {
                     //"wc:travelto", // set if GuidanceType == TravelTo
                 },
                 // This sets what ProjectileTagsList is interpeted as. Values:
-                // Blacklist - this weapon will NOT fire at any projectile if it has atleast one of the above tags
+                // BlacklistOr - this weapon will NOT fire at any projectile if it has atleast one of the above tags
+                // BlacklistAnd - this weapon will NOT fire at any projectile if it has ALL of the above flags
                 // WhitelistOr - this weapon will ONLY fire at a projectile if it has atleast one of the above tags
-                // WhitelistAnd - this weapon will ONLY fire at a projectile if it has ALL pf the above tags
+                // WhitelistAnd - this weapon will ONLY fire at a projectile if it has ALL of the above tags
                 // If you don't want to use this system, leave it on Blacklist!
-                ProjectileTagsMeaning = Blacklist,
+                ProjectileTagsMeaning = BlacklistOr,
                 SubSystems = new[] {
                     Thrust, Utility, Offense, Power, Production, Any, // Subsystem targeting priority: Offense, Utility, Power, Production, Thrust, Jumping, Steering, Any
                                                                       // Order matters! With the current setting weapons will target Thrust first, then Utility, then Offense, etc.
                 },
                 ClosestFirst = true, // Tries to pick closest targets first (blocks on grids, projectiles, etc...).
+                IgnoreDumbProjectiles = false,  // Don't fire at non-smart projectiles. If you're using projectile tags, ensure this is set to false as this overwrites the newer system
                 LockedSmartOnly = false, // Only fire at smart projectiles that are locked on to parent grid.
                 MinimumDiameter = 0, // Minimum diameter of threat to engage.
                 MaximumDiameter = 0, // Maximum diameter of threat to engage; 0 = unlimited.
@@ -169,6 +171,9 @@ namespace Scripts {
                             //"wc:mine", // set if GuidanceType is any of the mine types
                             //"wc:travelto", // set if GuidanceType == TravelTo
                         },
+                        // If false, then the above list will be the only tags the user can determine. If true, then the user can determine every tag BUT the ones listed above
+                        ListIsBlacklist = false,
+
                         // This allows the user to set what ProjectileTagsList is interpeted as if true. Atm you cannot remove options from the list (Blacklist, WhitelistOr, WhitelistAnd)
                         AllowUserWhitelistChange = false,
                     }

--- a/Data/Scripts/CoreParts/Weapon75ammo.cs
+++ b/Data/Scripts/CoreParts/Weapon75ammo.cs
@@ -70,42 +70,6 @@ namespace Scripts
                                   // It should be noted that this does NOT subtract the heat, use AmmoDef.AllowNegativeHeatModifier to subtract the desired amount.
             NpcSafe = false, // This is you tell npc moders that your ammo was designed with them in mind, if they tell you otherwise set this to false.
             NoGridOrArmorScaling = true, // If you enable this you can remove the damagescale section entirely.
-
-            // Thes are the "flags" that PDCs use to filter what projectiles they can shoot down (listed in Targeting.ProjectileThreats)
-            // This is where you set the Custom## flags used there for more filtering
-            // Alternatively, you can force enable the automatically set flags by listing them here, ie. labeling a Smart with approaches meant to be a drone as IsDrone
-            // You cannot forcefully disable flags
-            ProjectileFlagsOverride = new ProjectileFlags[]
-            {
-                Invalid,
-                //Custom01, Custom02, //... custom## ... Custom20
-                //AllCustom, // can be used in place of writing all 20 custom flags if you want all of them set for some reason
-
-                // other values that you can override here:
-                //IsDumb, // - Automatically set if the projectile guidance is None
-                //IsSmart, // - Automatically set if the projectile guidance is Smart
-                //IsDrone, // - Automatically set if the projectile guidance is DroneAdvanced
-                //IsMine, // - Automatically set if the projectile is one of the Mine guidance types
-                //IsTravelTo, // - Automatically set if the projectile guidance is TravelTo
-
-                //NoEwar, // - Automatically set if Ewar.Enable = false
-                //EwarEffect, // - Automatically set if Ewar.Enable = true and Ewar.Mode = Effect
-                //EwarField, // - Automatically set if Ewar.Enable = true and Ewar.Mode = Field
-                //Ewar, // - Equivalent to writing `EwarEffect, EwarField,`
-
-                //NonExplosive, // - Automatically set if ByBlockHit.Enable = false and EndOfLife.Enable = false
-                //BBHExplosive, // - Automatically set if ByBlockHit.Enable = true
-                //EOLExplosive, // - Automatically set if EndOfLife.Enable = true
-                //Explosive, // - Equivalent to writing `BBHExplosive, EOLExplosive,`
-
-                //NoFragments, // - Automatically set if the ammo def does not have a fragment defined
-                //HasFragments, // - Automatically set if the ammo def has a fragment defined
-
-                //AffectedByAntiSmarts, // - Automatically set if IsSmart = true and Trajectory.Smarts.IgnoreAntiSmarts = true
-                //IgnoresAntiSmarts, // - Automatically set if IsSmart = true and Trajectory.Smarts.IgnoreAntiSmarts = false
-
-                //All, // - Equivalent to writing out every flag on the list (and unused bits). Really not recommended
-            },
             Sync = new SynchronizeDef
             {
                 Full = false, // Use only on PD-killable (guided) projectiles that need to be replicated precisely on the client. It increases network traffic. When the projectile is fired (according to local game states), the clients don't locally spawn it, and instead, the server sends spawn packets to all clients, which spawns it exactly where the server spawned it. This also attaches a network identity to the projectile, allowing further replication, which you can control below.

--- a/Data/Scripts/CoreParts/Weapon75ammo.cs
+++ b/Data/Scripts/CoreParts/Weapon75ammo.cs
@@ -34,6 +34,7 @@ using static Scripts.Structure.WeaponDefinition.AmmoDef.GraphicDef.LineDef.Trace
 using static Scripts.Structure.WeaponDefinition.AmmoDef.GraphicDef.LineDef.Texture;
 using static Scripts.Structure.WeaponDefinition.AmmoDef.GraphicDef.DecalDef;
 using static Scripts.Structure.WeaponDefinition.AmmoDef.DamageScaleDef.DamageTypes.Damage;
+using static Scripts.Structure.WeaponDefinition.ProjectileFlags;
 
 namespace Scripts
 { // Don't edit above this line
@@ -69,6 +70,42 @@ namespace Scripts
                                   // It should be noted that this does NOT subtract the heat, use AmmoDef.AllowNegativeHeatModifier to subtract the desired amount.
             NpcSafe = false, // This is you tell npc moders that your ammo was designed with them in mind, if they tell you otherwise set this to false.
             NoGridOrArmorScaling = true, // If you enable this you can remove the damagescale section entirely.
+
+            // Thes are the "flags" that PDCs use to filter what projectiles they can shoot down (listed in Targeting.ProjectileThreats)
+            // This is where you set the Custom## flags used there for more filtering
+            // Alternatively, you can force enable the automatically set flags by listing them here, ie. labeling a Smart with approaches meant to be a drone as IsDrone
+            // You cannot forcefully disable flags
+            ProjectileFlagsOverride = new ProjectileFlags[]
+            {
+                Invalid,
+                //Custom01, Custom02, //... custom## ... Custom20
+                //AllCustom, // can be used in place of writing all 20 custom flags if you want all of them set for some reason
+
+                // other values that you can override here:
+                //IsDumb, // - Automatically set if the projectile guidance is None
+                //IsSmart, // - Automatically set if the projectile guidance is Smart
+                //IsDrone, // - Automatically set if the projectile guidance is DroneAdvanced
+                //IsMine, // - Automatically set if the projectile is one of the Mine guidance types
+                //IsTravelTo, // - Automatically set if the projectile guidance is TravelTo
+
+                //NoEwar, // - Automatically set if Ewar.Enable = false
+                //EwarEffect, // - Automatically set if Ewar.Enable = true and Ewar.Mode = Effect
+                //EwarField, // - Automatically set if Ewar.Enable = true and Ewar.Mode = Field
+                //Ewar, // - Equivalent to writing `EwarEffect, EwarField,`
+
+                //NonExplosive, // - Automatically set if ByBlockHit.Enable = false and EndOfLife.Enable = false
+                //BBHExplosive, // - Automatically set if ByBlockHit.Enable = true
+                //EOLExplosive, // - Automatically set if EndOfLife.Enable = true
+                //Explosive, // - Equivalent to writing `BBHExplosive, EOLExplosive,`
+
+                //NoFragments, // - Automatically set if the ammo def does not have a fragment defined
+                //HasFragments, // - Automatically set if the ammo def has a fragment defined
+
+                //AffectedByAntiSmarts, // - Automatically set if IsSmart = true and Trajectory.Smarts.IgnoreAntiSmarts = true
+                //IgnoresAntiSmarts, // - Automatically set if IsSmart = true and Trajectory.Smarts.IgnoreAntiSmarts = false
+
+                //All, // - Equivalent to writing out every flag on the list (and unused bits). Really not recommended
+            },
             Sync = new SynchronizeDef
             {
                 Full = false, // Use only on PD-killable (guided) projectiles that need to be replicated precisely on the client. It increases network traffic. When the projectile is fired (according to local game states), the clients don't locally spawn it, and instead, the server sends spawn packets to all clients, which spawns it exactly where the server spawned it. This also attaches a network identity to the projectile, allowing further replication, which you can control below.

--- a/Data/Scripts/CoreParts/script/PartCompile.cs
+++ b/Data/Scripts/CoreParts/script/PartCompile.cs
@@ -8,6 +8,7 @@ using static Scripts.Structure.WeaponDefinition.AnimationDef.PartAnimationSetDef
 using static Scripts.Structure.WeaponDefinition.AnimationDef;
 using static Scripts.Structure.WeaponDefinition.AnimationDef.PartAnimationSetDef.EventTriggers;
 using static Scripts.Structure.ArmorDefinition.ArmorType;
+using System.Linq;
 
 namespace Scripts
 {
@@ -32,6 +33,21 @@ namespace Scripts
         internal void UpgradeDefinitions(params UpgradeDefinition[] defs)
         {
             Container.UpgradeDefs = defs;
+        }
+
+        internal void ProjectileTags(params ProjectileTagDefinition[] defs)
+        {
+            Container.ProjectileTags = defs;
+        }
+        internal IEnumerable<T> Compile<T>(params IEnumerable<T>[] defs)
+        {
+            foreach (var arr in defs)
+                foreach (var def in arr)
+                    yield return def;
+        }
+        internal void ProjectileTagAssignments(params IEnumerable<ProjectileTagAssignment>[] defs)
+        {
+            Container.TagAssigmnents = Compile(defs).ToArray();
         }
 
         internal static void GetBaseDefinitions(out ContainerDefinition baseDefs)

--- a/Data/Scripts/CoreParts/script/Structure.cs
+++ b/Data/Scripts/CoreParts/script/Structure.cs
@@ -16,6 +16,29 @@ namespace Scripts
             [ProtoMember(2)] internal ArmorDefinition[] ArmorDefs;
             [ProtoMember(3)] internal UpgradeDefinition[] UpgradeDefs;
             [ProtoMember(4)] internal SupportDefinition[] SupportDefs;
+            [ProtoMember(5)] internal ProjectileTagDefinition[] ProjectileTags;
+            [ProtoMember(6)] internal ProjectileTagAssignment[] TagAssigmnents;
+        }
+
+        [ProtoContract]
+        public class ProjectileTagDefinition
+        {
+            [ProtoMember(1)] internal Tag Namespace;
+            [ProtoMember(2)] internal int DefinitionPriority;
+            [ProtoMember(3)] internal Tag[] Tags;
+
+            [ProtoContract]
+            public struct Tag
+            {
+                [ProtoMember(1)] internal string ID;
+                [ProtoMember(2)] internal string PublicName;
+            }
+        }
+        [ProtoContract]
+        public class ProjectileTagAssignment
+        {
+            [ProtoMember(1)] internal string Tag;
+            [ProtoMember(2)] internal string[] ProjectileAmmoNames;
         }
 
         [ProtoContract]
@@ -59,7 +82,7 @@ namespace Scripts
                 [ProtoMember(2)] internal HardwareDef HardWare;
                 [ProtoMember(3)] internal UiDef Ui;
                 [ProtoMember(4)] internal OtherDef Other;
-
+                [ProtoMember(5)] internal int DefinitionPriority;
 
                 [ProtoContract]
                 public struct UiDef
@@ -79,6 +102,7 @@ namespace Scripts
                     [ProtoMember(2)] internal HardwareType Type;
                     [ProtoMember(3)] internal int BlockDistance;
                     [ProtoMember(4)] internal float IdlePower;
+
                 }
 
                 [ProtoContract]
@@ -93,7 +117,6 @@ namespace Scripts
                     [ProtoMember(7)] internal bool StayCharged;
                 }
             }
-
         }
 
         [ProtoContract]
@@ -126,6 +149,7 @@ namespace Scripts
                 [ProtoMember(2)] internal HardwareDef HardWare;
                 [ProtoMember(3)] internal UiDef Ui;
                 [ProtoMember(4)] internal OtherDef Other;
+                [ProtoMember(5)] internal int DefinitionPriority;
 
                 [ProtoContract]
                 public struct UiDef
@@ -201,6 +225,7 @@ namespace Scripts
             [ProtoMember(2)] internal ArmorType Kind;
             [ProtoMember(3)] internal double KineticResistance;
             [ProtoMember(4)] internal double EnergeticResistance;
+            [ProtoMember(5)] internal int DefinitionPriority;
         }
 
         [ProtoContract]
@@ -213,132 +238,6 @@ namespace Scripts
             [ProtoMember(5)] internal AmmoDef[] Ammos;
             [ProtoMember(6)] internal string ModPath;
             [ProtoMember(7)] internal Dictionary<string, UpgradeValues[]> Upgrades;
-
-            [Flags]
-            [Serializable]
-            public enum ProjectileFlags : ulong
-            {
-                /// <summary>
-                /// By default set to All on weapons, ammo defs are set based on stats below if a definition is recieved with this for backwards compat.
-                /// </summary>
-                Invalid = 0,
-
-                /// <summary>
-                /// Custom flags for modders
-                /// </summary>
-                Custom01 = 1uL << 0,
-                Custom02 = 1uL << 1,
-                Custom03 = 1uL << 2,
-                Custom04 = 1uL << 3,
-                Custom05 = 1uL << 4,
-                Custom06 = 1uL << 5,
-                Custom07 = 1uL << 6,
-                Custom08 = 1uL << 7,
-                Custom09 = 1uL << 8,
-                Custom10 = 1uL << 9,
-                Custom11 = 1uL << 10,
-                Custom12 = 1uL << 11,
-                Custom13 = 1uL << 12,
-                Custom14 = 1uL << 13,
-                Custom15 = 1uL << 14,
-                Custom16 = 1uL << 15,
-                Custom17 = 1uL << 16,
-                Custom18 = 1uL << 17,
-                Custom19 = 1uL << 18,
-                Custom20 = 1uL << 19,
-
-                /// <summary>
-                /// Automatically set if the projectile guidance is not, Smart, Drone, or Mine (aka either None or TravelTo)
-                /// </summary>
-                IsDumb = 1uL << 20,
-                /// <summary>
-                /// Automatically set if the projectile guidance is Smart
-                /// </summary>
-                IsSmart = 1uL << 21,
-                /// <summary>
-                /// Automatically set if the projectile guidance is DroneAdvanced
-                /// </summary>
-                IsDrone = 1uL << 22,
-                /// <summary>
-                /// Automatically set if the projectile guidance is a Mine
-                /// </summary>
-                IsMine = 1uL << 23,
-                /// <summary>
-                /// // Automatically set if the projectile is TravelTo
-                /// </summary>
-                IsTravelTo = 1uL << 24,
-                /// <summary>
-                /// value for backwards compat when IgnoreDumbProjectiles = true
-                /// </summary>
-                IgnoreDumbProjectiles = IsSmart | IsDrone,
-
-                /// <summary>
-                /// Automatically set if Ewar.Enable = false
-                /// </summary>
-                NoEwar = 1uL << 25,
-                /// <summary>
-                /// Automatically set if Ewar.Enable = true and Ewar.Mode = Effect
-                /// </summary>
-                EwarEffect = 1uL << 26,
-                /// <summary>
-                /// Automatically set if Ewar.Enable = true and Ewar.Mode = Field
-                /// </summary>
-                EwarField = 1uL << 27,
-                /// <summary>
-                /// Value representing Ewar.Enable = true
-                /// </summary>
-                Ewar = EwarEffect | EwarField,
-
-                /// <summary>
-                /// Automatically set if ByBlockHit.Enable = false and EndOfLife.Enable = false
-                /// </summary>
-                NonExplosive = 1uL << 28,
-                /// <summary>
-                /// Automatically set if ByBlockHit.Enable = true
-                /// </summary>
-                BBHExplosive = 1uL << 29,
-                /// <summary>
-                /// Automatically set if EndOfLife.Enable = true
-                /// </summary>
-                EOLExplosive = 1uL << 30,
-                /// <summary>
-                /// Value representing ByBlockHit.Enable = true or EndOfLife.Enable = true
-                /// </summary>
-                Explosive = BBHExplosive | EOLExplosive,
-
-                /// <summary>
-                /// Automatically set if the ammo def does not have a fragment defined
-                /// </summary>
-                NoFragments = 1uL << 31,
-                /// <summary>
-                /// Automatically set if the ammo def has a fragment defined
-                /// </summary>
-                HasFragments = 1uL << 32,
-
-                /// <summary>
-                /// Automatically set if IsSmart = true and Trajectory.Smarts.IgnoreAntiSmarts = false
-                /// </summary>
-                IgnoresAntiSmarts = 1uL << 33,
-                /// <summary>
-                /// Automatically set if IsSmart = true and Trajectory.Smarts.IgnoreAntiSmarts = true
-                /// </summary>
-                AffectedByAntiSmarts = 1uL << 34,
-
-                // room for more if needed
-                // note that bit order matters for UI - larger values will be listed lower
-                // because of this adding more Custom variables is difficult if you want them to be grouped with the other Custom variables
-
-                /// <summary>
-                /// All ones
-                /// </summary>
-                All = ~Invalid,
-
-                /// <summary>
-                /// Value representing any of the custom flags
-                /// </summary>
-                AllCustom = Custom01 | Custom02 | Custom03 | Custom04 | Custom05 | Custom06 | Custom07 | Custom08 | Custom09 | Custom10 |
-                            Custom11 | Custom12 | Custom13 | Custom14 | Custom15 | Custom16 | Custom17 | Custom18 | Custom19 | Custom20,
-            }
 
             [ProtoContract]
             public struct ModelAssignmentsDef
@@ -382,7 +281,7 @@ namespace Scripts
                     ScanEnemyGrid,
                     ScanNeutralCharacter,
                     ScanUnOwnedGrid,
-                    ScanOwnersGrid
+                    ScanOwnersGrid,
                 }
 
                 public enum BlockTypes
@@ -395,6 +294,13 @@ namespace Scripts
                     Thrust,
                     Jumping,
                     Steering
+                }
+
+                public enum WhitelistSystem
+                {
+                    Blacklist,
+                    WhitelistOr,
+                    WhitelistAnd,
                 }
 
                 [ProtoMember(1)] internal int TopTargets;
@@ -412,6 +318,9 @@ namespace Scripts
                 [ProtoMember(13)] internal bool UniqueTargetPerWeapon;
                 [ProtoMember(14)] internal int MaxTrackingTime;
                 [ProtoMember(15)] internal bool ShootBlanks;
+                //[ProtoMember(16)] internal bool ExportTargets;
+                //[ProtoMember(17)] internal string ChannelId;
+                //[ProtoMember(18)] internal int ExportLimit;
                 [ProtoMember(19)] internal CommunicationDef Communications;
                 [ProtoMember(20)] internal bool FocusOnly;
                 [ProtoMember(21)] internal bool EvictUniqueTargets;
@@ -420,28 +329,8 @@ namespace Scripts
                 [ProtoMember(24)] internal bool AllowSwitchTargetPriority;
                 [ProtoMember(25)] internal bool AllowFireDistribution;
                 [ProtoMember(26)] internal bool AdvancedFireDistribution;
-                [ProtoMember(27)] internal ulong ProjectileThreatsInternal; // ulong is needed or ProtoBuf throws a fit :(
-                [ProtoIgnore]
-                internal ProjectileFlags[] ProjectileThreats
-                {
-                    set
-                    {
-                        ProjectileThreatsInternal = (ulong)ProjectileFlags.Invalid;
-                        foreach (var flag in value)
-                        {
-                            if (flag == ProjectileFlags.Invalid)
-                            {
-                                ProjectileThreatsInternal = (ulong)ProjectileFlags.Invalid;
-                                return;
-                            }
-
-                            ProjectileThreatsInternal |= (ulong)flag;
-                        }
-                    }
-                }
-                [ProtoMember(28)] internal bool RequireAllProjectileThreats;
-
-                
+                [ProtoMember(27)] internal string[] ProjectileTagsList;
+                [ProtoMember(28)] internal WhitelistSystem ProjectileTagsMeaning;
 
                 [ProtoContract]
                 public struct CommunicationDef
@@ -476,6 +365,7 @@ namespace Scripts
                     [ProtoMember(11)] internal bool TargetPersists;
                     [ProtoMember(12)] internal bool StoreLimitPerBlock;
                     [ProtoMember(13)] internal int MaxConnections;
+
                 }
             }
 
@@ -535,6 +425,7 @@ namespace Scripts
                     [ProtoMember(8)] internal EventTriggers[] TriggerOnce;
                     [ProtoMember(9)] internal EventTriggers[] ResetEmissives;
                     [ProtoMember(10)] internal ResetConditions Resets;
+
                 }
 
                 [ProtoContract]
@@ -638,8 +529,9 @@ namespace Scripts
                 [ProtoMember(14)] internal bool CanShootSubmerged;
                 [ProtoMember(15)] internal bool NpcSafe;
                 [ProtoMember(16)] internal bool ScanTrackOnly;
-                [ProtoMember(17)] internal bool CanTargetSubmerged; 
+                [ProtoMember(17)] internal bool CanTargetSubmerged;
                 [ProtoMember(18)] internal float DeviateShotAngleSGModifier;
+                [ProtoMember(19)] internal int DefinitionPriority;
 
                 [ProtoContract]
                 public struct LoadingDef
@@ -683,6 +575,9 @@ namespace Scripts
                         [ProtoMember(2)] internal float HeatThresholdEnd;
                         [ProtoMember(3)] internal float RofAt0Heat;
                         [ProtoMember(4)] internal float RofAt100Heat;
+
+                        // if DegradeRof is active (heat went above HeatThresholdStart and has not went below HeatThresholdEnd,
+                        // then lerp between RofAt0Heat and RofAt100Heat using heat percentage.
                     }
                 }
 
@@ -700,54 +595,14 @@ namespace Scripts
                     [ProtoMember(8)] internal bool DisableSupportingPD;
                     [ProtoMember(9)] internal bool ProhibitShotDelay;
                     [ProtoMember(10)] internal bool ProhibitBurstCount;
-                    [ProtoMember(11)] internal ProjectileFlagsToggleDef UiFlagsToggle;
+                    [ProtoMember(11)] internal UiSetTagsDef UiSetTags;
 
                     [ProtoContract]
-                    public struct ProjectileFlagsToggleDef
+                    public struct UiSetTagsDef
                     {
                         [ProtoMember(1)] internal bool Enable;
-                        [ProtoMember(2)] internal ulong ProjectileThreatsTogglesInternal; // ulong is needed or ProtoBuf throws a fit :(
-                        [ProtoIgnore]
-                        internal ProjectileFlags[] ProjectileThreatToggles
-                        {
-                            set
-                            {
-                                ProjectileThreatsTogglesInternal = (ulong)ProjectileFlags.Invalid;
-                                foreach (var flag in value)
-                                {
-                                    if (flag == ProjectileFlags.Invalid)
-                                    {
-                                        ProjectileThreatsTogglesInternal = (ulong)ProjectileFlags.Invalid;
-                                        return;
-                                    }
-
-                                    ProjectileThreatsTogglesInternal |= (ulong)flag;
-                                }
-                            }
-                        }
-
-                        [ProtoMember(3)] internal string Custom01DisplayName;
-                        [ProtoMember(4)] internal string Custom02DisplayName;
-                        [ProtoMember(5)] internal string Custom03DisplayName;
-                        [ProtoMember(6)] internal string Custom04DisplayName;
-                        [ProtoMember(7)] internal string Custom05DisplayName;
-                        [ProtoMember(8)] internal string Custom06DisplayName;
-                        [ProtoMember(9)] internal string Custom07DisplayName;
-                        [ProtoMember(10)] internal string Custom08DisplayName;
-                        [ProtoMember(11)] internal string Custom09DisplayName;
-                        [ProtoMember(12)] internal string Custom10DisplayName;
-                        [ProtoMember(13)] internal string Custom11DisplayName;
-                        [ProtoMember(14)] internal string Custom12DisplayName;
-                        [ProtoMember(15)] internal string Custom13DisplayName;
-                        [ProtoMember(16)] internal string Custom14DisplayName;
-                        [ProtoMember(17)] internal string Custom15DisplayName;
-                        [ProtoMember(18)] internal string Custom16DisplayName;
-                        [ProtoMember(19)] internal string Custom17DisplayName;
-                        [ProtoMember(20)] internal string Custom18DisplayName;
-                        [ProtoMember(21)] internal string Custom19DisplayName;
-                        [ProtoMember(22)] internal string Custom20DisplayName;
-
-                        [ProtoMember(23)] internal bool RequireAllProjectileThreatsToggle;
+                        [ProtoMember(2)] internal string[] ProjectileTagsList;
+                        [ProtoMember(3)] internal bool AllowUserWhitelistChange;
                     }
                 }
 
@@ -885,25 +740,7 @@ namespace Scripts
                 [ProtoMember(34)] internal bool IgnoreGrids;
                 [ProtoMember(35)] internal bool AllowNegativeHeatModifier;
                 [ProtoMember(36)] internal int HeatNeededToFire;
-                [ProtoMember(37)] internal ulong ProjectileFlagsInternal; // ulong is needed or ProtoBuf throws a fit :(
-                [ProtoIgnore]
-                internal ProjectileFlags[] ProjectileFlagsOverride
-                {
-                    set
-                    {
-                        ProjectileFlagsInternal = (ulong)ProjectileFlags.Invalid;
-                        foreach (var flag in value)
-                        {
-                            if (flag == ProjectileFlags.Invalid)
-                            {
-                                ProjectileFlagsInternal = (ulong)ProjectileFlags.Invalid;
-                                return;
-                            }
 
-                            ProjectileFlagsInternal |= (ulong)flag;
-                        }
-                    }
-                }
 
                 [ProtoContract]
                 public struct SynchronizeDef
@@ -979,7 +816,6 @@ namespace Scripts
                         {
                             Energy,
                             Kinetic,
-                            ShieldDefault,
                         }
 
                         [ProtoMember(1)] internal Damage Base;
@@ -1097,7 +933,6 @@ namespace Scripts
                         [ProtoMember(6)] internal OffsetEffectDef OffsetEffect;
                         [ProtoMember(7)] internal bool DropParentVelocity;
 
-
                         [ProtoContract]
                         public struct OffsetEffectDef
                         {
@@ -1199,7 +1034,7 @@ namespace Scripts
                     [ProtoMember(9)] internal float Offset;
                     [ProtoMember(10)] internal int MaxChildren;
                     [ProtoMember(11)] internal TimedSpawnDef TimedSpawns;
-                    [ProtoMember(12)] internal bool FireSound; // not used, can remove
+                    [ProtoMember(12)] internal bool FireSound; // not used can remove
                     [ProtoMember(13)] internal Vector3D AdvOffset;
                     [ProtoMember(14)] internal bool ArmWhenHit;
                     [ProtoMember(15)] internal Vector2D AdvRotationOffset;
@@ -1267,6 +1102,7 @@ namespace Scripts
                     [ProtoMember(7)] internal Vector3D Rotation;
                     [ProtoMember(8)] internal Randomize RotationVariance;
 
+
                     [ProtoContract]
                     public struct ComponentDef
                     {
@@ -1290,6 +1126,7 @@ namespace Scripts
                         Pooled,
                         Exponential,
                     }
+
                     public enum AoeShape
                     {
                         Round,
@@ -1309,6 +1146,7 @@ namespace Scripts
                         [ProtoMember(5)] internal float MaxAbsorb;
                         [ProtoMember(6)] internal Falloff Falloff;
                         [ProtoMember(7)] internal AoeShape Shape;
+
                     }
 
                     [ProtoContract]
@@ -1347,7 +1185,7 @@ namespace Scripts
                         Push,
                         Pull,
                         Tractor,
-                        AntiSmartv2
+                        AntiSmartv2,
                     }
 
                     public enum EwarMode
@@ -1555,7 +1393,7 @@ namespace Scripts
                     [ProtoMember(14)] internal uint MaxTrajectoryTime;
                     [ProtoMember(15)] internal ApproachDef[] Approaches;
                     [ProtoMember(16)] internal double TotalAcceleration;
-                    [ProtoMember(17)] internal OnHitDef OnHit; // Deprecated
+                    [ProtoMember(17)] internal OnHitDef OnHit; //Deprecated
                     [ProtoMember(18)] internal float DragPerSecond;
                     [ProtoMember(19)] internal float DragMinSpeed;
 

--- a/Data/Scripts/CoreParts/script/Structure.cs
+++ b/Data/Scripts/CoreParts/script/Structure.cs
@@ -1,5 +1,7 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel;
+using KeenSoftwareHouse.Library.Extensions;
 using ProtoBuf;
 using VRageMath;
 
@@ -212,6 +214,132 @@ namespace Scripts
             [ProtoMember(6)] internal string ModPath;
             [ProtoMember(7)] internal Dictionary<string, UpgradeValues[]> Upgrades;
 
+            [Flags]
+            [Serializable]
+            public enum ProjectileFlags : ulong
+            {
+                /// <summary>
+                /// By default set to All on weapons, ammo defs are set based on stats below if a definition is recieved with this for backwards compat.
+                /// </summary>
+                Invalid = 0,
+
+                /// <summary>
+                /// Custom flags for modders
+                /// </summary>
+                Custom01 = 1uL << 0,
+                Custom02 = 1uL << 1,
+                Custom03 = 1uL << 2,
+                Custom04 = 1uL << 3,
+                Custom05 = 1uL << 4,
+                Custom06 = 1uL << 5,
+                Custom07 = 1uL << 6,
+                Custom08 = 1uL << 7,
+                Custom09 = 1uL << 8,
+                Custom10 = 1uL << 9,
+                Custom11 = 1uL << 10,
+                Custom12 = 1uL << 11,
+                Custom13 = 1uL << 12,
+                Custom14 = 1uL << 13,
+                Custom15 = 1uL << 14,
+                Custom16 = 1uL << 15,
+                Custom17 = 1uL << 16,
+                Custom18 = 1uL << 17,
+                Custom19 = 1uL << 18,
+                Custom20 = 1uL << 19,
+
+                /// <summary>
+                /// Automatically set if the projectile guidance is not, Smart, Drone, or Mine (aka either None or TravelTo)
+                /// </summary>
+                IsDumb = 1uL << 20,
+                /// <summary>
+                /// Automatically set if the projectile guidance is Smart
+                /// </summary>
+                IsSmart = 1uL << 21,
+                /// <summary>
+                /// Automatically set if the projectile guidance is DroneAdvanced
+                /// </summary>
+                IsDrone = 1uL << 22,
+                /// <summary>
+                /// Automatically set if the projectile guidance is a Mine
+                /// </summary>
+                IsMine = 1uL << 23,
+                /// <summary>
+                /// // Automatically set if the projectile is TravelTo
+                /// </summary>
+                IsTravelTo = 1uL << 24,
+                /// <summary>
+                /// value for backwards compat when IgnoreDumbProjectiles = true
+                /// </summary>
+                IgnoreDumbProjectiles = IsSmart | IsDrone,
+
+                /// <summary>
+                /// Automatically set if Ewar.Enable = false
+                /// </summary>
+                NoEwar = 1uL << 25,
+                /// <summary>
+                /// Automatically set if Ewar.Enable = true and Ewar.Mode = Effect
+                /// </summary>
+                EwarEffect = 1uL << 26,
+                /// <summary>
+                /// Automatically set if Ewar.Enable = true and Ewar.Mode = Field
+                /// </summary>
+                EwarField = 1uL << 27,
+                /// <summary>
+                /// Value representing Ewar.Enable = true
+                /// </summary>
+                Ewar = EwarEffect | EwarField,
+
+                /// <summary>
+                /// Automatically set if ByBlockHit.Enable = false and EndOfLife.Enable = false
+                /// </summary>
+                NonExplosive = 1uL << 28,
+                /// <summary>
+                /// Automatically set if ByBlockHit.Enable = true
+                /// </summary>
+                BBHExplosive = 1uL << 29,
+                /// <summary>
+                /// Automatically set if EndOfLife.Enable = true
+                /// </summary>
+                EOLExplosive = 1uL << 30,
+                /// <summary>
+                /// Value representing ByBlockHit.Enable = true or EndOfLife.Enable = true
+                /// </summary>
+                Explosive = BBHExplosive | EOLExplosive,
+
+                /// <summary>
+                /// Automatically set if the ammo def does not have a fragment defined
+                /// </summary>
+                NoFragments = 1uL << 31,
+                /// <summary>
+                /// Automatically set if the ammo def has a fragment defined
+                /// </summary>
+                HasFragments = 1uL << 32,
+
+                /// <summary>
+                /// Automatically set if IsSmart = true and Trajectory.Smarts.IgnoreAntiSmarts = false
+                /// </summary>
+                IgnoresAntiSmarts = 1uL << 33,
+                /// <summary>
+                /// Automatically set if IsSmart = true and Trajectory.Smarts.IgnoreAntiSmarts = true
+                /// </summary>
+                AffectedByAntiSmarts = 1uL << 34,
+
+                // room for more if needed
+                // note that bit order matters for UI - larger values will be listed lower
+                // because of this adding more Custom variables is difficult if you want them to be grouped with the other Custom variables
+
+                /// <summary>
+                /// All ones
+                /// </summary>
+                All = ~Invalid,
+
+                /// <summary>
+                /// Value representing any of the custom flags
+                /// </summary>
+                AllCustom = Custom01 | Custom02 | Custom03 | Custom04 | Custom05 | Custom06 | Custom07 | Custom08 | Custom09 | Custom10 |
+                            Custom11 | Custom12 | Custom13 | Custom14 | Custom15 | Custom16 | Custom17 | Custom18 | Custom19 | Custom20,
+            }
+
             [ProtoContract]
             public struct ModelAssignmentsDef
             {
@@ -292,7 +420,29 @@ namespace Scripts
                 [ProtoMember(24)] internal bool AllowSwitchTargetPriority;
                 [ProtoMember(25)] internal bool AllowFireDistribution;
                 [ProtoMember(26)] internal bool AdvancedFireDistribution;
+                [ProtoMember(27)] internal ulong ProjectileThreatsInternal; // ulong is needed or ProtoBuf throws a fit :(
+                [ProtoIgnore]
+                internal ProjectileFlags[] ProjectileThreats
+                {
+                    set
+                    {
+                        ProjectileThreatsInternal = (ulong)ProjectileFlags.Invalid;
+                        foreach (var flag in value)
+                        {
+                            if (flag == ProjectileFlags.Invalid)
+                            {
+                                ProjectileThreatsInternal = (ulong)ProjectileFlags.Invalid;
+                                return;
+                            }
+
+                            ProjectileThreatsInternal |= (ulong)flag;
+                        }
+                    }
+                }
+                [ProtoMember(28)] internal bool RequireAllProjectileThreats;
+
                 
+
                 [ProtoContract]
                 public struct CommunicationDef
                 {
@@ -550,6 +700,55 @@ namespace Scripts
                     [ProtoMember(8)] internal bool DisableSupportingPD;
                     [ProtoMember(9)] internal bool ProhibitShotDelay;
                     [ProtoMember(10)] internal bool ProhibitBurstCount;
+                    [ProtoMember(11)] internal ProjectileFlagsToggleDef UiFlagsToggle;
+
+                    [ProtoContract]
+                    public struct ProjectileFlagsToggleDef
+                    {
+                        [ProtoMember(1)] internal bool Enable;
+                        [ProtoMember(2)] internal ulong ProjectileThreatsTogglesInternal; // ulong is needed or ProtoBuf throws a fit :(
+                        [ProtoIgnore]
+                        internal ProjectileFlags[] ProjectileThreatToggles
+                        {
+                            set
+                            {
+                                ProjectileThreatsTogglesInternal = (ulong)ProjectileFlags.Invalid;
+                                foreach (var flag in value)
+                                {
+                                    if (flag == ProjectileFlags.Invalid)
+                                    {
+                                        ProjectileThreatsTogglesInternal = (ulong)ProjectileFlags.Invalid;
+                                        return;
+                                    }
+
+                                    ProjectileThreatsTogglesInternal |= (ulong)flag;
+                                }
+                            }
+                        }
+
+                        [ProtoMember(3)] internal string Custom01DisplayName;
+                        [ProtoMember(4)] internal string Custom02DisplayName;
+                        [ProtoMember(5)] internal string Custom03DisplayName;
+                        [ProtoMember(6)] internal string Custom04DisplayName;
+                        [ProtoMember(7)] internal string Custom05DisplayName;
+                        [ProtoMember(8)] internal string Custom06DisplayName;
+                        [ProtoMember(9)] internal string Custom07DisplayName;
+                        [ProtoMember(10)] internal string Custom08DisplayName;
+                        [ProtoMember(11)] internal string Custom09DisplayName;
+                        [ProtoMember(12)] internal string Custom10DisplayName;
+                        [ProtoMember(13)] internal string Custom11DisplayName;
+                        [ProtoMember(14)] internal string Custom12DisplayName;
+                        [ProtoMember(15)] internal string Custom13DisplayName;
+                        [ProtoMember(16)] internal string Custom14DisplayName;
+                        [ProtoMember(17)] internal string Custom15DisplayName;
+                        [ProtoMember(18)] internal string Custom16DisplayName;
+                        [ProtoMember(19)] internal string Custom17DisplayName;
+                        [ProtoMember(20)] internal string Custom18DisplayName;
+                        [ProtoMember(21)] internal string Custom19DisplayName;
+                        [ProtoMember(22)] internal string Custom20DisplayName;
+
+                        [ProtoMember(23)] internal bool RequireAllProjectileThreatsToggle;
+                    }
                 }
 
 
@@ -686,6 +885,25 @@ namespace Scripts
                 [ProtoMember(34)] internal bool IgnoreGrids;
                 [ProtoMember(35)] internal bool AllowNegativeHeatModifier;
                 [ProtoMember(36)] internal int HeatNeededToFire;
+                [ProtoMember(37)] internal ulong ProjectileFlagsInternal; // ulong is needed or ProtoBuf throws a fit :(
+                [ProtoIgnore]
+                internal ProjectileFlags[] ProjectileFlagsOverride
+                {
+                    set
+                    {
+                        ProjectileFlagsInternal = (ulong)ProjectileFlags.Invalid;
+                        foreach (var flag in value)
+                        {
+                            if (flag == ProjectileFlags.Invalid)
+                            {
+                                ProjectileFlagsInternal = (ulong)ProjectileFlags.Invalid;
+                                return;
+                            }
+
+                            ProjectileFlagsInternal |= (ulong)flag;
+                        }
+                    }
+                }
 
                 [ProtoContract]
                 public struct SynchronizeDef

--- a/Data/Scripts/CoreParts/script/Structure.cs
+++ b/Data/Scripts/CoreParts/script/Structure.cs
@@ -298,7 +298,8 @@ namespace Scripts
 
                 public enum WhitelistSystem
                 {
-                    Blacklist,
+                    BlacklistOr,
+                    BlacklistAnd,
                     WhitelistOr,
                     WhitelistAnd,
                 }
@@ -602,7 +603,8 @@ namespace Scripts
                     {
                         [ProtoMember(1)] internal bool Enable;
                         [ProtoMember(2)] internal string[] ProjectileTagsList;
-                        [ProtoMember(3)] internal bool AllowUserWhitelistChange;
+                        [ProtoMember(3)] internal bool ListIsBlacklist;
+                        [ProtoMember(4)] internal bool AllowUserWhitelistChange;
                     }
                 }
 

--- a/Data/Scripts/CoreParts/script/Structure.cs
+++ b/Data/Scripts/CoreParts/script/Structure.cs
@@ -298,10 +298,10 @@ namespace Scripts
 
                 public enum WhitelistSystem
                 {
-                    BlacklistOr,
-                    BlacklistAnd,
-                    WhitelistOr,
-                    WhitelistAnd,
+                    BlacklistOr = 0,
+                    BlacklistAnd = 1,
+                    WhitelistOr = 2,
+                    WhitelistAnd = 3,
                 }
 
                 [ProtoMember(1)] internal int TopTargets;


### PR DESCRIPTION
# Changelog

PD Tag System (See section below for how it all works) 
- In `WeaponDefinition.TargetingDef`
  - Added `enum WhitelistSystem`
  - Added `string[] ProjectileTagsList`
  - Added `WhitelistSystem ProjectileTagsMeaning`
- In `WeaponDefinition.HardpointDef.UiDef`
  - Added struct `UiSetTagsDef`
     - `bool Enable`
     - `string[] ProjectileTagsList`
     - `bool ListIsBlacklist`
     - `bool AllowUserWhitelistChange`
- Added class `ProjectileTagDefinition`
  - Added struct `Tag`
    - `string ID`
    - `string PublicName`
  - `Tag Namespace`
  - `int DefinitionPriority`
  - `Tag[] Tags`
- Added class `ProjectileTagAssignment`
  - `string Tag`
  - `string[] ProjectileAmmoNames`
- Added new functions `ProjectileTags` and `ProjectileTagAssignments` to `MasterConfig.cs`
- Added new CoreParts file `ProjectileTags.cs`
- Added terminal messages stating what tags and what interpetation of those tags the weapon is using and what tags the ammo the weapon shoots uses.
### When updating make sure to update everything in `script` and not just `Structure.cs`! You'll need to update the header of every weapon file too (all the using X;s)

Definition Priority System (See section below for how it works)
- Added int `DefinitionPriority` to `UpgradeDefinition.HardpointDef`
- Added int `DefinitionPriority` to `ArmorDefinition`
- Added int `DefinitionPriority` to `SupportDefinition.HardpointDef`
- Added int `DefinitionPriority` to `WeaponDefinition.HardpointDef`

# The PD Tag System (put on wiki)
This is a new, more complex system for subdividing projectiles into categories, and turrets can then act on them via allowing/disallowing targeting certain categories. Consider this an extension of `Targeting.IgnoreDumbProjectiles`.

For turrets, tags can be "hardcoded" defined in `Targeting.ProjectileTagsList`, and the method the turret uses to interpet this list is based on `ProjectileTagsMeaning`.
- `BlacklistOr` - the weapon will NOT fire at any projectile if it has atleast one of the above tags
- `BlacklistAnd` - the weapon will NOT fire at any projectile if it has ALL of the above flags
- `WhitelistOr` - the weapon will ONLY fire at a projectile if it has atleast one of the above tags
- `WhitelistAnd` - the weapon will ONLY fire at a projectile if it has ALL of the above tags
(where above tags refers to `Targeting.ProjectileTagsList`)
Additionally, it is possible to let users assign them individually, and this is done through the `Hardpoint.Ui.UiSetTags` settings. `Enable` enables this to happen, `UiSetTags.ProjectileTagsList` is the list of tags that are either the only ones allowable, or blocked from being set by the user, depending on whether `ListIsBlacklist` (if true then they are the ones being blocked from being set). `AllowUserWhitelistChange` adds a dropdown menu to set the meaning of the lists, effectively giving them control over `ProjectileTagsMeaning` from above.
- The two lists operate in tandem but are only interpeted as the same things. This means that the hardcoded list will be joined with whatever values the user set based on `ProjectileTagsMeaning` to filter targets.
- This UI requires advanced settings to be on to be shown.

Image of the terminal UI with tags from an as of yet unreleased mod, with the UI set to whitelist tags from that mod as well as WC drones:
<img width="531" height="579" alt="image" src="https://github.com/user-attachments/assets/1270882a-0e48-4f67-8efb-28cc6f688fac" />
Hovering over each tag in the list will show the internal tag as well.
<img width="503" height="175" alt="image" src="https://github.com/user-attachments/assets/810332f1-d01a-41ea-8b1f-b4e2f4997c78" />
This is an image of the weapon info of the same weapon, listing the selected tags in the UI as well as the whitelist mode. This will not be shown if no tags are listed.
<img width="504" height="149" alt="image" src="https://github.com/user-attachments/assets/5aad0e66-d0e8-4815-ac96-5a8f6adfae3f" />
This is an image of the weapon info showing the currrently selected ammo's tags. This will show up for every projectile if they are targetable (Health > 0).

For ammos, most of these tags are manually defined and assigned in `ProjectileTags.cs` files, although WC automatically defines a couple based on a projectile's guidance type:
`wc:dumb` - set if GuidanceType = None
`wc:smart` - set if GuidanceType = Smart
`wc:drone` - set if GuidanceType = DroneAdvanced
`wc:mine` - set if GuidanceType is any of the mine types
`wc:travelto` - set if GuidanceType = TravelTo

# The Definition Priority System (put on wiki)
Previously:
Having multiple weapon definitions on the same block with the same part name would crash WC during setup as there were duplicate weapons essentially. This meant that in order to modify a WC mod, you had to either copy the entire mod and get permission from the mod author, or use WC server overrides, which do not contain every variable and cannot add new ammo types. It has also meant that WC vanilla replacers required some way of telling WC not to load its own vanilla replacer, and this was done through a WCVanilla name tag or file. Even then, loading multiple WC vanilla replacers would crash even if they were say bundled as a larger modpack.

Now:
If there are multiple definitions with the same part name & subtype ID (like say someone is adjusting stats of another's mod), then the definition with the highest priority will be loaded.
For people making their own mod, its recommended to leave this at zero.
For people MODIFYING other people's mod, its recommended to set this at anything greater than zero (ie. 1) so your changes override the original mod, and list that mod as a dependency.
This effectively allows mod adjuster-like behavior without relying on mod load order, although the entire definition must be copied for it to work properly
- those modifying stats can just have the definitions in their place w/o copying any models, sbc files, or sounds to the modified mod.



Some notes:
- WC Server config overrides will still work and still take priority.
- This has depreciated all WCVanilla tags; they are no longer needed and no longer checked for. Internally, the vanilla weapons have a priority of -2.1 billion (int.MinValue) and so will always be replaced by a replacer if one is present w/o the need to check.
- This is done *per subtype*, not *per weapon definition*
- When a weapon definition is overriden, it will log in debug.log
- WC Mod API Get all definitions will give all WeaponDefinitions, including overriden ones
- ammostats and wepstats will correctly list values even if overridden.