### PR TITLE
Drone Additions

### DIFF
--- a/Data/Scripts/CoreParts/Weapon75Part.cs
+++ b/Data/Scripts/CoreParts/Weapon75Part.cs
@@ -225,7 +225,8 @@ namespace Scripts {
                     EnergyPriority = 0, // Deprecated.
                     MuzzleCheck = false, // Whether the weapon should check LOS from each individual muzzle in addition to the scope.
                     AllowScopeOutsideObb = false, // If true, the actual scope position will be used regardless if it is outside the bounds of the weapon block.  If false (default) the ray origin will be adjusted to be inside the bounds.
-                    DisableLosCheck = false, // Do not perform LOS checks at all... not advised for self tracking weapons
+                    DisableLosCheck = false, // Do not perform LOS checks at all (except against its own grid)
+                    DisableOwnGridLosCheck = false, // If true, this weapon will not perform LOS checks against its own grid.
                     NoVoxelLosCheck = false, // If set to true this ignores voxels for LOS checking.. which means weapons will fire at targets behind voxels.  However, this can save cpu in some situations, use with caution. 
                     Debug = false, // Force enables debug mode - will output damage stats to WC log.
                     RestrictionRadius = 0, // Prevents other blocks of this type from being placed within this distance of the centre of the block.
@@ -234,6 +235,7 @@ namespace Scripts {
                     ProhibitLGTargeting = false, // If true, prohibits block from targeting Large Grids (best used in server-specific weapon packs)
                     ProhibitSGTargeting = false, // If true, prohibits block from targeting Small Grids (best used in server-specific weapon packs)
                     ProhibitSubsystemChanges = false, // If true, disables subsystem selection by player.  Should only target subsystem list in order as specified in Targeting
+                    AllowNoTargetFiring = false, // If true, allows the weapon to fire smart ammos even without a target without the projectile being fired in "Test Mode" (and therefore not being retargetable)
                 },
                 Loading = new LoadingDef
                 {

--- a/Data/Scripts/CoreParts/Weapon75ammo.cs
+++ b/Data/Scripts/CoreParts/Weapon75ammo.cs
@@ -34,7 +34,6 @@ using static Scripts.Structure.WeaponDefinition.AmmoDef.GraphicDef.LineDef.Trace
 using static Scripts.Structure.WeaponDefinition.AmmoDef.GraphicDef.LineDef.Texture;
 using static Scripts.Structure.WeaponDefinition.AmmoDef.GraphicDef.DecalDef;
 using static Scripts.Structure.WeaponDefinition.AmmoDef.DamageScaleDef.DamageTypes.Damage;
-using static Scripts.Structure.WeaponDefinition.ProjectileFlags;
 
 namespace Scripts
 { // Don't edit above this line
@@ -69,6 +68,7 @@ namespace Scripts
             HeatNeededToFire = 0, // Makes an ammo require heat in order to be able to be fired.
                                   // It should be noted that this does NOT subtract the heat, use AmmoDef.AllowNegativeHeatModifier to subtract the desired amount.
             NpcSafe = false, // This is you tell npc moders that your ammo was designed with them in mind, if they tell you otherwise set this to false.
+            GridsTargetSeekersTargetingThis = false, // If true, any Smart projectiles targeting this projectile will be added to grid threat lookups (and therefore will be shot at)
             NoGridOrArmorScaling = true, // If you enable this you can remove the damagescale section entirely.
             Sync = new SynchronizeDef
             {
@@ -413,8 +413,10 @@ namespace Scripts
                                 MaxRuns = 0, // 0 means unlimited, defines how many times this entry can return true. 
                                 Weight = Random(0, 99), // The approachId that rolls the highest number will be selected
                                 End1WeightMod = 0, // multiplies the weight Start and End value by this number, if both End conditions were true the highest roll between them wins, 0 means disabled
-                                End2WeightMod = 0,
+                                End2WeightMod = 0, // If set to double.MaxValue, then if this end condition is met, this entry is chosen immediately; if multiple approaches would be chosen order of highest to lowest
                                 End3WeightMod = 0,
+                                End4WeightMod = 0,
+                                End5WeightMod = 0,
                             },
                             new WeightedIdListDef
                             {
@@ -424,6 +426,8 @@ namespace Scripts
                                 End1WeightMod = 0, 
                                 End2WeightMod = 0,
                                 End3WeightMod = 0,
+                                End4WeightMod = 0,
+                                End5WeightMod = 0,
                             },
                             new WeightedIdListDef
                             {
@@ -433,6 +437,8 @@ namespace Scripts
                                 End1WeightMod = 0, 
                                 End2WeightMod = 0,
                                 End3WeightMod = 0,
+                                End4WeightMod = 0,
+                                End5WeightMod = 0,
                             },
                         },
                         Operators = StartEnd_And, // Controls how the start and end conditions are matched:  StartEnd_And*, StartEnd_Or, StartAnd_EndOr,StartOr_EndAnd,
@@ -440,24 +446,47 @@ namespace Scripts
                         ForceRestart = false, // This forces the ReStartCondition when the end condition is met no matter if the start condition was met or not.  
 
                         // Start/End conditions
-                        StartCondition1 = Lifetime, // Each condition type is either >= or <= the corresponding value defined below.
-                                                    // Ignore(skip this condition)*, DistanceFromPositionC[<=], DistanceToPositionC[>=], DistanceFromPositionB[<=], DistanceToPositionB[>=]
-                                                    // DistanceFromTarget[<=], DistanceToTarget[>=], DistanceFromEndTrajectory[<=], DistanceToEndTrajectory[>=], Lifetime[>=], DeadTime[<=],
-                                                    // MinTravelRequired[>=], MaxTravelRequired[<=], Spawn(per stage), DesiredElevation(tolerance can be set with ElevationTolerance),
-                                                    // NextTimedSpawn[<=], SinceTimedSpawn[>=], RelativeLifetime[>=], RelativeDeadTime[<=], RelativeSpawns[>=], EnemyTargetLoss[>=],
-                                                    // RelativeHealthLost[>=], HealthRemaining[<=],
-                                                    // *NOTE* DO NOT set start1 and start2 or end1 and end2 to same condition
-                        StartCondition2 = Ignore, 
-                        EndCondition1 = DesiredElevation, 
+                        // Each condition type is either >= or <= the corresponding value defined below.
+                        // Ignore(skip this condition), Spawn (always true),
+                        // DistanceFromPositionC[<=], DistanceToPositionC[>=] - distance in meters from the defined PositionC
+                        // DistanceFromPositionB[<=], DistanceToPositionB[>=] - distance in meters from the defined PositionB
+                        // DistanceFromTarget[<=], DistanceToTarget[>=] - distance in meters from the current target
+                        // DistanceFromEndTrajectory[<=], DistanceToEndTrajectory[>=] - distance in meters from the end trajectory
+                        // Lifetime[>=], DeadTime[<=] - total time alive
+                        // MinTravelRequired[>=], MaxTravelRequired[<=] - distance projectile has traveled so far
+                        // DesiredElevation(tolerance can be set with ElevationTolerance) - projectile is given value±ElevationTolerance above the defined elevation plane
+                        // NextTimedSpawn[<=], SinceTimedSpawn[>=] - time in ticks since the last timed spawn was spawned
+                        // RelativeSpawns[>=] - time in ticks since the last timed spawn in this approach was spawned
+                        // RelativeLifetime[>=], RelativeDeadTime[<=] - relative time alive
+                        // EnemyTargetLoss[>=], ReaquiredTarget[<=] - time in ticks the projectile has no target
+                        // RelativeHealthLost[>=], HealthRemaining[<=] - current HP
+                        // EnemySeekersGreaterThanEqualTo[>=], EnemySeekersLessThanEqualTo[<=] - number of enemy Smart munitions targeting this munition
+                        StartCondition1 = Lifetime, 
+                        
+                        StartCondition2 = Ignore,
+
+                        EndCondition1 = DesiredElevation,
                         EndCondition2 = Ignore,
                         EndCondition3 = Ignore,
+                        EndCondition4 = Ignore,
+                        EndCondition5 = Ignore,
                         // Start/End thresholds -- both conditions are evaluated before activation, use Ignore to skip
                         Start1Value = 60,
                         Start2Value = 0,
+
                         End1Value = 1000, 
                         End2Value = 0,
-                        End3Value = 0, 
-                        // Special triggers when the start/end conditions are met (DoNothing*, EndProjectile, EndProjectileOnRestart, StorePositionA, StorePositionB, StorePositionC, Refund)
+                        End3Value = 0,
+                        End4Value = 0,
+                        End5Value = 0,
+
+                        // Special triggers when the start/end conditions are met
+                        // DoNothing
+                        // EndProjectile - Despawns the projectile
+                        // EndProjectileOnRestart - Despawns the projectile if end conditions are met before start conditions
+                        // StorePositionA, StorePositionB, StorePositionC - Stores this position for later use
+                        // Refund - Triggers refund actions based on HeatRefund and ReloadRefund (those two wil do nothing if this is not set)
+                        // ForceRetarget - Forces the projectile to do a target calculation
                         StartEvent = DoNothing, 
                         EndEvent = DoNothing,  
                         

--- a/Data/Scripts/CoreParts/script/Structure.cs
+++ b/Data/Scripts/CoreParts/script/Structure.cs
@@ -693,6 +693,8 @@ namespace Scripts
                     [ProtoMember(12)] internal bool ProhibitLGTargeting;
                     [ProtoMember(13)] internal bool ProhibitSGTargeting;
                     [ProtoMember(14)] internal bool ProhibitSubsystemChanges;
+                    [ProtoMember(15)] internal bool DisableOwnGridLosCheck;
+                    [ProtoMember(16)] internal bool AllowNoTargetFiring;
                 }
 
                 [ProtoContract]
@@ -742,7 +744,7 @@ namespace Scripts
                 [ProtoMember(34)] internal bool IgnoreGrids;
                 [ProtoMember(35)] internal bool AllowNegativeHeatModifier;
                 [ProtoMember(36)] internal int HeatNeededToFire;
-
+                [ProtoMember(37)] internal bool GridsTargetSeekersTargetingThis;
 
                 [ProtoContract]
                 public struct SynchronizeDef
@@ -1466,6 +1468,9 @@ namespace Scripts
                             DistanceToTarget,
                             DistanceFromEndTrajectory,
                             DistanceToEndTrajectory,
+                            ReaquiredTarget,
+                            EnemySeekersGreaterThanEqualTo,
+                            EnemySeekersLessThanEqualTo,
                         }
 
                         public enum UpRelativeTo
@@ -1538,6 +1543,7 @@ namespace Scripts
                             StorePositionA,
                             StorePositionB,
                             StorePositionC,
+                            ForceRetarget,
                         }
 
                         [ProtoContract]
@@ -1550,6 +1556,8 @@ namespace Scripts
                             [ProtoMember(4)] public double End2WeightMod;
                             [ProtoMember(5)] public int MaxRuns;
                             [ProtoMember(6)] public double End3WeightMod;
+                            [ProtoMember(7)] public double End4WeightMod;
+                            [ProtoMember(8)] public double End5WeightMod;
                         }
 
                         [ProtoMember(1)] internal ReInitCondition RestartCondition;
@@ -1619,6 +1627,10 @@ namespace Scripts
                         [ProtoMember(65)] internal double End3Value;
                         [ProtoMember(66)] internal bool SwapNavigationType;
                         [ProtoMember(67)] internal bool ElevationRelativeToC;
+                        [ProtoMember(68)] internal Conditions EndCondition4;
+                        [ProtoMember(69)] internal double End4Value;
+                        [ProtoMember(70)] internal Conditions EndCondition5;
+                        [ProtoMember(71)] internal double End5Value;
                     }
 
                     [ProtoContract]


### PR DESCRIPTION
# Additions
- Added bool `WeaponDef.HardPoint.Other.DisableOwnGridLosCheck`
   - disables checking the weapon's own grid for LOS check... and yes  `DisableLosCheck` *didn't* do this
- Added bool `AmmoDef.GridsTargetSeekersTargetingThis`
  - Adds any smart projectiles targeting this projectile to grid lookup tables to be targeted by point defense
- Added value `ReaquiredTarget` to enum `TrajectoryDef.ApproachDef.Conditions`
  - less than or equal to counterpart to `EnemyTargetLoss`
- Added value `EnemySeekersGreaterThanEqualTo` to enum `TrajectoryDef.ApproachDef.Conditions`
  - returns true when the number of seekers (Smart projectiles) targeting this projectile >= value
- Added value `EnemySeekersLessThanEqualTo` to enum `TrajectoryDef.ApproachDef.Conditions`
  - returns true when the number of seekers (Smart projectiles) targeting this projectile <= value
- Added value `ForceRetarget` to enum `TrajectoryDef.ApproachDef.StageEvents` -Calls NewTarget() when the values are met to force target aquisition
- Added Conditions `EndCondition4`, `EndCondition5` to `TrajectoryDef.ApproachDef.WeightedIdListDef`
  - same as 1/2/3 but this time 4/5
- Added double `End4Value`, `End5Value` to `TrajectoryDef.ApproachDef.WeightedIdListDef`
  - same as 1/2/3 but this time 4/5
- Added `End4WeightMod`, `End5WeightMod` to `TrajectoryDef.ApproachDef.WeightedIdListDef`
  - same as 1/2/3 but this time 4/5
- setting `TrajectoryDef.ApproachDef.WeightedIdListDef`'s EndXWeightMod's to `double.MaxValue` will forcefully choose the given approach if that end condition is met
- Added `WeaponDef.HardPointDef.OtherDef.AllowNoTargetFiring`, which allows firing smart ammos without having a target and without setting the target as test mode (so they can pick new targets that may appear)

# Bugfixes
- Fixed Approaches end condition 3 not actually working (& refactored approach condition code to NOT inline these)
- Fixed Approaches condition Or always returning true if condition 1 or 2 was `Ignore`
- Fixed Approaches `UpOriginDirection` using OriginForward rather than OriginUp
- Fixed log init errors not showing properly and an OOM exception caused when moving logs that were too big
- Fixed issue where projectiles would fail to remove themselves from their target's Seeker list if they were killed